### PR TITLE
version 1.0 following introduction to traitlets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,10 +20,10 @@ done automagically in the background.
 For example, if it were desirable to keep track of element changes in a list, ``spectate`` could be
 used to observe ``list.__setitiem__`` in order to be notified when a user sets the value of an element
 in the list. To do this, we would first create a ``EventfulList`` using ``watched_type``, and then
-store pairs of callbacks to an instance of ``EventfulList`` using the public method ``spectator_callback``.
-Each pair is registered by specifying, with keywords, whether the callback should be triggered
-``before``, and/or or ``after`` a given method is called - hereafter refered to as "beforebacks"
-and "afterbacks" respectively.
+store pairs of callbacks to an instance of ``EventfulList`` using its `instance_spectator` attribute.
+Each pair is registered by calling the `instance_spectator`'s `callback` method. You can then specify,
+with keywords, whether the callback should be triggered ``before``, and/or or ``after`` a given method
+is called - hereafter refered to as "beforebacks" and "afterbacks" respectively.
 
 Beforebacks
 -----------
@@ -59,9 +59,7 @@ Afterbacks
         +   ``'name'`` - the name of the method which was called
         +   ``'value'`` - the value returned by the method
         +   ``'before'`` - the value returned by the respective beforeback
-        +   ``'error'`` - None, or the error encountered in the beforeback
 
-+ Responcible for raising beforeback errors.
 + Should not ``return``
 
 Example
@@ -101,7 +99,7 @@ spectator is notified, and will print once the action is complete:
 
     elist = EventfulList([1, 2, 3])
 
-    elist.spectator_callback('__setitem__',
+    elist.instance_spectator.callback('__setitem__',
         before=pass_on_old_value,
         after=print_element_change)
 
@@ -111,8 +109,8 @@ Prints ``{0: 1} -> {0: 0}``
 
 Under The Hood
 --------------
-Methods are tracked by using ``watched_type`` to create a new class with ``method_spectator`` descriptors in
-the place of specified methods. At the time an instance of this class is created, a spectator is assigned
-under the attribute name ``_instance_spectator``. When a ``method_spectator`` is accessed through an instance,
+Methods are tracked by using ``watched_type`` to create a new class with ``MethodSpectator`` descriptors in
+the place of specified methods. At the time an instance of this class is created, a `Spectator` is assigned
+under the attribute name ``instance_spectator``. When a ``MethodSpectator`` is accessed through an instance,
 the descriptor will return a new wrapper function that will redirect to ``Spectator.wrapper``, which triggers
 the beforebacks and afterbacks registered to the instance.

--- a/examples/advanced.ipynb
+++ b/examples/advanced.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -66,8 +66,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Beforebacks\n",
-    "-----------\n",
+    "Using Closures\n",
+    "--------------\n",
+    "\n",
+    "In the basic example we created beforebacks and afterbacks seperately when defining our eventful list. However it is also possible to define an afterback as closure inside a beforeback. This allows the afterback to capture the same information that would otherwise need to be passed to it from a beforeback inside its scope.\n",
+    "\n",
+    "\n",
+    "Callbacks\n",
+    "---------\n",
     "\n",
     "+ Have a signature of ``(instance, call)``\n",
     "\n",
@@ -78,27 +84,16 @@
     "        + ``'args'`` - the arguments which that method will call\n",
     "        + ``'kwargs'`` - the keywords which that method will call\n",
     "\n",
-    "+ Can ``return`` a value which gets passed on to its respective afterback.\n",
-    "+ If an error is encountered, the wrapper will ``return`` the original ``call``\n",
-    "as if it were that of the beforeback, and set ``error`` in the ``answer``\n",
-    "bunch of its afterback. This way, if the base method call is valid, it's not\n",
-    "obstructed by a raised beforeback. Thus, beforeback errors should be handled\n",
-    "in an afterback.\n",
+    "+ Can ``return`` a closue which is called as an afterback.\n",
     "\n",
-    "Afterbacks\n",
-    "----------\n",
+    "Closures\n",
+    "--------\n",
     "\n",
-    "+ Have a signature of ``(instance, answer)``\n",
+    "+ Have a signature of ``(value)``\n",
     "\n",
-    "    + ``instance`` is the owner of the method\n",
-    "    + ``answer`` is a ``Bunch`` with the keys:\n",
+    "    + ``'value'`` - the value returned by the method\n",
+    "    + All other information is already contained in the closures scope.\n",
     "\n",
-    "        + ``'name'`` - the name of the method which was called\n",
-    "        + ``'value'`` - the value returned by the method\n",
-    "        + ``'before'`` - the value returned by the respective beforeback\n",
-    "        + ``'error'`` - None, or the error encountered in the beforeback\n",
-    "\n",
-    "+ Responcible for raising beforeback errors.\n",
     "+ Should not ``return``"
    ]
   },
@@ -110,40 +105,34 @@
    },
    "outputs": [],
    "source": [
-    "# beforebacks\n",
+    "def djoin(d1, d2):\n",
+    "    new = d1.copy()\n",
+    "    d1.update(d2)\n",
+    "    return new\n",
     "\n",
-    "def will_update(inst, call):\n",
-    "    return {k: inst.get(k, Empty) for k, v\n",
-    "        in dict(call.args[0]).items()}\n",
+    "def item_change(inst, key):\n",
+    "    old = inst.get(key, Empty)\n",
+    "    def printit(value):\n",
+    "        new = inst.get(key, Empty)\n",
+    "        if new != old:\n",
+    "            print(\"{%s: %s} -> {%s: %s}\" %\n",
+    "                (key, old, key, new))\n",
+    "    return printit\n",
     "\n",
-    "def will_change_item(inst, call):\n",
-    "    return call.args[0], inst.get(call.args[0], Empty)\n",
+    "def before_item_change(inst, call):\n",
+    "    return item_change(inst, call.args[0])\n",
     "\n",
-    "def will_pop_item(inst, call):\n",
-    "    k = inst.keys()[0]\n",
-    "    return k, inst[k]\n",
+    "def before_popitem(inst, call):\n",
+    "    return item_change(inst, tuple(inst.keys())[0])\n",
     "\n",
-    "# afterbacks\n",
+    "def before_update(inst, call):\n",
+    "    call_list = [item_change(inst, k) for k in\n",
+    "        set(call.args[0]) | set(call.kwargs)]\n",
+    "    def after_update(value):\n",
+    "        return [c(value) for c in call_list]\n",
+    "    return after_update\n",
     "\n",
-    "def did_update(inst, answer):\n",
-    "    for k, v in answer.before.items():\n",
-    "        did_change_item(inst, Bunch(before=(k, v)))\n",
-    "\n",
-    "def did_change_item(inst, answer):\n",
-    "    key, old = answer.before\n",
-    "    new = inst.get(key, Empty)\n",
-    "    if new != old:\n",
-    "        print(\"{%s: %s} -> {%s: %s}\" %\n",
-    "            (key, old, key, new))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Instances of `EventfulDict` have a public method `spectator_callback` which is used to store unique callback pairs. \n",
-    "\n",
-    "Each pair can have a beforeback, and/or an afterback which are specified in the method signature with the keywords `before` and `after`."
+    "    "
    ]
   },
   {
@@ -156,19 +145,13 @@
    "source": [
     "edict = EventfulDict({'a': 1, 'b':2})\n",
     "\n",
-    "edict.spectator_callback(\n",
-    "    '__setitem__', '__delitem__',\n",
-    "    'setdefault', 'pop',\n",
-    "    before=will_change_item,\n",
-    "    after=did_change_item)\n",
+    "edict.instance_spectator.callback(\n",
+    "    ('__setitem__', '__delitem__', 'pop',\n",
+    "     'setdefault'), before_item_change)\n",
     "\n",
-    "edict.spectator_callback('popitem',\n",
-    "    before=will_pop_item,\n",
-    "    after=did_change_item)\n",
+    "edict.instance_spectator.callback('popitem', before_popitem)\n",
     "\n",
-    "edict.spectator_callback('update',\n",
-    "    before=will_update,\n",
-    "    after=did_update)"
+    "edict.instance_spectator.callback('update', before_update)"
    ]
   },
   {
@@ -206,28 +189,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'a': 1, 'b': 2}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "edict"
-   ]
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
    "display_name": "Python 2",
    "language": "python",
@@ -236,14 +207,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -76,9 +76,7 @@
     "        + ``'name'`` - the name of the method which was called\n",
     "        + ``'value'`` - the value returned by the method\n",
     "        + ``'before'`` - the value returned by the respective beforeback\n",
-    "        + ``'error'`` - None, or the error encountered in the beforeback\n",
     "\n",
-    "+ Responcible for raising beforeback errors.\n",
     "+ Should not ``return``"
    ]
   },
@@ -114,25 +112,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instances of `EventfulList` have a public method `spectator_callback` which is used to store unique callback pairs. \n",
-    "\n",
-    "Each pair can have a beforeback, and/or an afterback which are specified in the method signature with the keywords `before` and `after`."
+    "Instances of `EventfulList` have a public attribute `instance_spectator` which is a `Spectator`. This object is relatively simple, and only has methods to add, delete, and trigger callbacks. To register a callback to a method, use the spectator's `callback` method. It's signatures is `(name, before, after)` where '`name`' is the name of the method you're observing, and `before` and `after` are a beforeback and an afterback. Callbacks are ultimately triggered by `MethodSpectator` descriptors that access the instance spectator (these descriptors are generally hidden from the user and shouldn't be tampered with)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "elist = EventfulList([1, 2, 3])\n",
     "\n",
-    "elist.spectator_callback('pop',\n",
-    "    '__delitem__', '__setitem__',\n",
-    "    before=pass_on_old_value,\n",
-    "    after=print_element_change)"
+    "methods = ('pop', '__delitem__', '__setitem__')\n",
+    "\n",
+    "# callback accepts a method name string or,\n",
+    "# as in this case, a list or tuple of names\n",
+    "elist.instance_spectator.callback(methods,\n",
+    "        before=pass_on_old_value,\n",
+    "        after=print_element_change)"
    ]
   },
   {
@@ -216,6 +215,7 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
    "display_name": "Python 2",
    "language": "python",
@@ -224,14 +224,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/spectate/__init__.py
+++ b/spectate/__init__.py
@@ -1,1 +1,1 @@
-from spectate import *
+from .spectate import *

--- a/spectate/spectate.py
+++ b/spectate/spectate.py
@@ -1,33 +1,23 @@
-import re
+import six
 import types
 import inspect
-from weakref import ref
+
+def getargspec(func):
+    if isinstance(func, types.FunctionType) or isinstance(func, types.MethodType):
+        return inspect.getargspec(func)
+    else:
+        # no signature introspection is available for this type
+        return inspect.ArgSpec(None, 'args', 'kwargs', None)
 
 class WatchedType(object):
     """An eventful base class purely for introspection"""
     pass
 
-class Sentinel(object):
-    """A placeholder default value in _wrapper_src for introspection
-
-    Any default value that is not set, i.e. the value is left as
-    as a Sentinel instance, never gets passed to the base method.
-    This means the base method will use a default value as, just
-    like the user of the wrapper intended.
-
-    Thus _wrapper_src, does not waste variable names trying to
-    eval the true default value into the function signature.
-    """
-    def __init__(self, obj):
-        if isinstance(obj, (str, unicode)):
-            self.name = obj
-        else:
-            self.name = repr(obj)
-    def __repr__(self):
-        return self.name
-
 
 class Bunch(dict):
+    # Copyright (c) Jupyter Development Team.
+    # Distributed under the terms of the Modified BSD License.
+
     """A dict with attribute-access"""
     def __getattr__(self, key):
         try:
@@ -44,38 +34,8 @@ class Bunch(dict):
         names.extend(self.keys())
         return names
 
-
-_wrapper_src = """def {name}({signature}):
-    __args = [{args}]
-    for __val in ({defaults}):
-        if not isinstance(__val, __sentinel):
-            __args.append(__val)
-    __args.extend({varargs})
-    return __spectator.wrapper(__instance, '{name}',
-        tuple(__args), {keywords}.copy())
-"""
-
-def source_wrapper_exception(exc, filename, lineno):
-    """A factory for formating errors arising from wrapper source code
-
-    Parameters
-    ----------
-    exc: Exception
-        The exception instance raise by the wrapper
-    filename: str
-        The file the wrapper is defined in
-    line: int
-        The line number of the error
-
-    Returns
-    -------
-    An error of the same type. with the formated method, and a new
-    attribute ``info`` containing the original exception, along with
-    the name and line of the file in which is was raised.
-    """
-    inst = exc.__class__(str(exc) + ' @ ' +
-        filename + '[lineno:%s]' % lineno)
-    return inst
+    def copy(self):
+        return Bunch(self)
 
 
 class Spectator(object):
@@ -85,210 +45,147 @@ class Spectator(object):
         self.subclass = subclass
         self._callback_registry = {}
 
-    def register_callbacks(self, name, before=None, after=None, delete=False):
-        if not isinstance(getattr(self.subclass, name), method_spectator):
-            raise ValueError("No method specator for '%s'" % name)
-        if before is None and after is None:
-            raise ValueError("No pre or post '%s' callbacks were given" % name)
-        elif ((before is not None and not callable(before))
-            or (after is not None and not callable(after))):
-            raise ValueError("Expected a callables")
+    def callback(self, name, before=None, after=None):
+        for name in (name if isinstance(name, (list, tuple)) else (name,)):
+            if not isinstance(getattr(self.subclass, name), MethodSpectator):
+                raise ValueError("No method specator for '%s'" % name)
+            if before is None and after is None:
+                raise ValueError("No pre or post '%s' callbacks were given" % name)
+            elif ((before is not None and not callable(before))
+                or (after is not None and not callable(after))):
+                raise ValueError("Expected a callables")
 
+            if name in self._callback_registry:
+                l = self._callback_registry[name]
+            else:
+                l = []
+                self._callback_registry[name] = l
+            l.append((before, after))
+
+    def remove_callback(self, name, before=None, after=None):
         if name in self._callback_registry:
             l = self._callback_registry[name]
         else:
             l = []
             self._callback_registry[name] = l
+        l.remove((before, after))
 
-        t = (before, after)
-        if delete:
-            try:
-                l.remove(t)
-            except:
-                raise ValueError("The before and after pair %r does "
-                    "not exist in the callback registry" % t)
-        else:
-            l.append(t)
-
-    def wrapper(self, inst, name, args, kwargs):
+    def wrapper(self, name, args, kwargs):
         """A callback made prior to calling the given base method
 
         Parameters
         ----------
-        inst: any
-            The instance being spectated
         name: str
-            The name of the method while will be called
+            The name of the method that will be called
         args: tuple
             The arguments that will be passed to the base method
         kwargs: dict
-            A copy of the keywords args that will be passed to the base method
+            The keyword args that will be passed to the base method
         """
-        beforebacks, afterbacks = zip(*self._callback_registry.get(name, []))
+        if name in self._callback_registry:
+            beforebacks, afterbacks = zip(*self._callback_registry.get(name, []))
 
-        hold = []
-        for b in beforebacks:
-            if b is not None:
-                try:
+            hold = []
+            for b in beforebacks:
+                if b is not None:
                     call = Bunch(name=name,
                         kwargs=kwargs.copy(),
                         args=args[1:])
-                    v = b(inst, call)
-                except Exception as e:
-                    e = call
+                    v = b(args[0], call)
                 else:
-                    e = None
-            else:
-                v = None
-                e = None
-            hold.append(v)
+                    v = None
+                hold.append(v)
 
-        out = getattr(self.base, name)(*args, **kwargs)
+            out = getattr(self.base, name)(*args, **kwargs)
 
-        for a, bval in zip(afterbacks, hold):
-            if a is not None:
-                a(inst, Bunch(before=v,
-                    name=name, value=out,
-                    error=e))
-        return out
+            for a, bval in zip(afterbacks, hold):
+                if a is not None:
+                    a(args[0], Bunch(before=bval,
+                        name=name, value=out))
+                elif callable(bval):
+                    # the beforeback's return value was an
+                    # afterback that expects to be called
+                    bval(out)
+            return out
+        else:
+            return getattr(self.base, name)(*args, **kwargs)
 
 
-class method_spectator(object):
+class MethodSpectator(object):
 
     _compile_count = 0
+    _src_str = """def {name}({signature}):
+    args, varargs, kwargs = [{args}], {varargs}, {keywords}
+    args.extend(varargs)
+    return args[0].instance_spectator.wrapper(
+        '{name}', tuple(args), kwargs.copy())"""
 
-    def __init__(self, name):
-        self.code = None
-        self.name = name
+    def __init__(self, base, name):
+        self.base, self.name = base, name
+        aspec = getargspec(self.basemethod)
+        self.defaults = aspec.defaults
+        self.code, self.defaults = self._code(aspec)
 
-    def _gen_src_str(self, func, reserved_names=None):
-        """Creates an excecutable method wrapper string
+    @property
+    def basemethod(self):
+        return getattr(self.base, self.name)
 
-        Parameters
-        ----------
-        func: the base method
-            Attempts to extract the function signature. Defaults to
-            ``*args, **kwargs`` if introspection is unavailable.
-        reserved_names: iterable
-            A sequence of variables used internally by the source code.
-            An error is raise if any of the reserved names are found
-            in the base method's call signature.
-        """
-        if isinstance(func, types.FunctionType):
-            aspec = inspect.getargspec(func)
-        elif isinstance(func, types.MethodType):
-            aspec = inspect.getargspec(func)
-            # instance is provided by func
-            del aspec.args[0]
-        else:
-            # no introspection is available for this type
-            aspec = inspect.ArgSpec((), 'args', 'kwargs', ())
-
-        a, kw = aspec.varargs, aspec.keywords
-
-        if reserved_names:
-            # see if argument names conflict with those
-            # reserved by the wrapper source string
-            msg = ("signature conflicts with reserved"
-                    " name '%s' in new wrapper method")
-            for name in list(reserved_names) + ["_"]:
-                if name in aspec.args or name in a or name in kw:
-                    raise ValueError(msg % name)
-
-        # split point between defaults and normal args
-        split = len(aspec.args or ()) - len(aspec.defaults or ())
-        # remove tailing brackets from list conversion
-        defaults = str(aspec.args[split:])[1:-1]
-        args = str(aspec.args[:split])[1:-1]
-        # list values were `repr`ed - remove "'"
-        defaults = defaults.replace("'", "")
-        args = args.replace("'", "")
-        if len(defaults):
-            defaults += ", "
-        if len(args):
-            args += ", "
-
-        signature = args
-
-        if len(defaults) != 0:
-            for d, v in zip(*(defaults, aspec.defaults)):
-                signature += d + '=' + '__sentinel(' + str(v) + ')' + ', '
+    def _code(self, aspec):
+        # list values were repred - remove quotes
+        args = str(aspec.args)[1:-1].replace("'", "")
+        signature = args + (", " if args else "")
         if aspec.varargs is not None:
             signature += '*' + aspec.varargs + ', '
         if aspec.keywords is not None:
             signature += '**' + aspec.keywords
         if signature.endswith(', '):
             signature = signature[:-2]
+        src = self._src_str.format(name=self.name,
+            signature=signature, args=args,
+            varargs=aspec.varargs or (),
+            keywords=aspec.keywords or {})
+        filename = "watched-method-gen-%d" % self._compile_count
+        code = compile(src, filename, 'single')
+        MethodSpectator._compile_count += 1
+        return code, aspec.defaults
 
-        return _wrapper_src.format(name=self.name, signature=signature,
-            args=args, defaults=defaults, varargs=a or (), keywords=kw or {})
+    def new_wrapper(self, inst):
+        evaldict = {}
+        eval(self.code, evaldict)
+        # extract wrapper by name
+        new = evaldict[self.name]
+        # assign docstring and defaults
+        new.__doc__ = self.basemethod.__doc__
+        new.__defaults__ = self.defaults
+        return types.MethodType(new, inst)
 
-    def _eval_src(self, src, evaldict):
-        """Evaluate the source string with the given eval dict.
-
-        Compiled code is reused. Set ``self.code`` to ``None`` to reset.
-        """
-        if self.code is None:
-            filename = "watched-method-gen-%d" % self._compile_count
-            try:
-                self.code = compile(src, filename, 'single')
-            except Exception, e:
-                s = "Failed to compile - " + str(e)
-                raise e.__class__(s)
-            else:
-                self._compile_count += 1
-        try:
-            eval(self.code, evaldict)
-        except Exception, e:
-            s = "Failed to evaluate - " + str(e)
-            raise e.__class__(s)
+    def __call__(self, *args, **kwargs):
+        return self.new_wrapper(None, self.base)(*args, **kwargs)
 
     def __get__(self, inst, cls):
         if inst is None:
             return self
+        elif inst.instance_spectator is None:
+            return types.MethodType(self.basemethod, inst)
         else:
-            evaldict = {'__spectator': inst._instance_spectator,
-                '__sentinel': Sentinel, '__instance': inst}
-            func = getattr(inst._instance_spectator.base, self.name)
+            return self.new_wrapper(inst)
 
-            src = self._gen_src_str(func, evaldict.keys())
-            self._eval_src(src, evaldict)
 
-            # extract func and assign docs
-            newf = evaldict[self.name]
-            newf.__doc__ = func.__doc__
-            return types.MethodType(newf, inst)
-
-def watched_type(name, base, *notify_on, **kwargs):
+def watched_type(name, base, *notify_on):
     classdict = base.__dict__.copy()
-    classdict.update(kwargs.get('classdict', {}))
 
     def __new__(cls, *args, **kwargs):
         inst = base.__new__(cls, *args, **kwargs)
-        object.__setattr__(inst, '_instance_spectator',
-            kwargs.get('spectator_type', Spectator)(base, cls))
+        object.__setattr__(inst, 'instance_spectator', Spectator(base, cls))
         return inst
 
     classdict['__new__'] = __new__
-
-    def spectator_callback(self, *names, **callbacks):
-        """Register a preemptive callback for method calls
-
-        Parameters
-        ----------
-        **callbacks : callables
-            The keys can be a near matches or 
-        """
-        for n in names:
-            self._instance_spectator.register_callbacks(n, **callbacks)
-
-    classdict['spectator_callback'] = spectator_callback
 
     for method in notify_on:
         if not hasattr(base, method):
             raise ValueError("Cannot notify on '%s', because '%s' "
                 "instances lack this method" % (method, base.__name__))
         else:
-            classdict[method] = method_spectator(method)
+            classdict[method] = MethodSpectator(base, method)
 
     return type(name, (base, WatchedType), classdict)

--- a/spectate/tests/test_spectate.py
+++ b/spectate/tests/test_spectate.py
@@ -1,0 +1,98 @@
+import inspect
+from ..spectate import watched_type, WatchedType, MethodSpectator, Spectator, Bunch
+
+def test_watched_type():
+	WatchedList = watched_type(
+		'WatchedList', list, 'append')
+
+	assert WatchedList.__name__ == 'WatchedList'
+	assert issubclass(WatchedList, list)
+	assert issubclass(WatchedList, WatchedType)
+	assert isinstance(WatchedList.append, MethodSpectator)
+
+	wl = WatchedList()
+	assert hasattr(wl, 'instance_spectator')
+	assert isinstance(wl.instance_spectator, Spectator)
+
+def test_method_spectator():
+	MethodSpectator._compile_count = 0
+	WatchedList = watched_type(
+		'WatchedList', list, 'append')
+	assert MethodSpectator._compile_count == 1
+	append = WatchedList.append
+
+	assert append.basemethod is list.append
+	assert append.name == 'append'
+
+	wl = WatchedList()
+	wl.append(1)
+	wl.append(2)
+	assert wl == [1, 2]
+
+	class Thing(object):
+		def func(self, a, b, c=None, d=None, *e, **f):
+			pass
+
+	WatchedThing = watched_type('WatchedThing', Thing, 'func')
+	assert MethodSpectator._compile_count == 2
+	assert (inspect.getargspec(Thing().func) ==
+		inspect.getargspec(WatchedThing().func))
+
+
+class Thing(object):
+	def func(inst, a, b, c=None, d=None, *e, **f):
+		return inst,  a, b, c, d, e, f
+
+def check_answer(checklist, inst, name, a, b, c=None, d=None, *e, **f):
+	args, kwargs = condense(a, b, c, d, *e, **f)
+	checklist.append(Bunch(
+		name=name,
+		value=(inst, a, b, c, d, e, f),
+		before=Bunch(
+			name=name,
+			args=args,
+			kwargs=kwargs))
+	)
+	getattr(inst, name)(a, b, c, d, *e, **f)
+
+condense = lambda *a, **kw: (a, kw)
+
+
+def test_beforeback_afterback():
+	checklist = []
+
+	WatchedThing = watched_type('WatchedThing', Thing, 'func')
+	wt = WatchedThing()
+
+	# callback stores call information
+	def beforeback(inst, call):
+		return call
+	def afterback(inst, answer):
+		assert checklist[-1] == answer
+
+	wt.instance_spectator.callback('func',
+		before=beforeback, after=afterback)
+
+	check_answer(checklist, wt, 'func', 1, 2, c=3)
+	check_answer(checklist, wt, 'func', 1, 2, d=3)
+	check_answer(checklist, wt, 'func', 1, 2, 3, 4, 5)
+	check_answer(checklist, wt, 'func', 1, 2, d=3, f=4)
+
+def test_callback_closure():
+	checklist = []
+
+	WatchedThing = watched_type('WatchedThing', Thing, 'func')
+	wt = WatchedThing()
+
+	def callback(inst, call):
+		def closure(value):
+			assert (checklist[-1] == Bunch(
+				name=call.name, value=value,
+				before=call))
+
+	wt.instance_spectator.callback('func', callback)
+
+	check_answer(checklist, wt, 'func', 1, 2, c=3)
+	check_answer(checklist, wt, 'func', 1, 2, d=3)
+	check_answer(checklist, wt, 'func', 1, 2, 3, 4, 5)
+	check_answer(checklist, wt, 'func', 1, 2, d=3, f=4)


### PR DESCRIPTION
These changes reflect the use `spectate` in (https://github.com/ipython/traitlets/pull/327).

See README and examples for current usage.