### PR TITLE
rework using watch, expose approach

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,9 +69,9 @@ Example
 
 .. code-block:: python
 
-    from spectate import watched_type
+    from spectate import expose_as
 
-    EventfulList = watched_type('EventfulList', list, '__setitem__')
+    EventfulList = expose_as('EventfulList', list, '__setitem__')
 
     def pass_on_old_value(inst, call):
         """The beforeback"""
@@ -99,9 +99,9 @@ spectator is notified, and will print once the action is complete:
 
 .. code-block:: python
 
-    elist = EventfulList([1, 2, 3])
+    elist, spectator = watch(EventfulList, [1, 2, 3])
 
-    elist.instance_spectator.callback('__setitem__',
+    spectator.callback('__setitem__',
         before=pass_on_old_value,
         after=print_element_change)
 
@@ -111,8 +111,8 @@ Prints ``{0: 1} -> {0: 0}``
 
 Under The Hood
 --------------
-Methods are tracked by using ``watched_type`` to create a new class with ``MethodSpectator`` descriptors in
-the place of specified methods. At the time an instance of this class is created, a `Spectator` is assigned
-under the attribute name ``instance_spectator``. When a ``MethodSpectator`` is accessed through an instance,
-the descriptor will return a new wrapper function that will redirect to ``Spectator.wrapper``, which triggers
-the beforebacks and afterbacks registered to the instance.
+Methods are tracked by using ``expose`` or (``expose_as``) to create a new class with ``MethodSpectator``
+descriptors in the place of specified methods. Then, a user will create a ``Spectator`` using ``watch``
+which is stored on the instance under the attribute ``_instance_spectator``. When a ``MethodSpectator``
+is accessed through an instance, the descriptor will return a wrapper that will redirect to
+``Spectator.wrapper``, which triggers the beforebacks and afterbacks registered to the instance.

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,7 @@ Beforebacks
 
 + Have a signature of ``(instance, call)``
 
-+   ``instance`` is the owner of the method
-
+    +   ``instance`` is the owner of the method
     +   ``call`` is a ``Bunch`` with the keys:
 
         + ``'name'`` - the name of the method which was called

--- a/examples/advanced.ipynb
+++ b/examples/advanced.ipynb
@@ -19,7 +19,7 @@
    },
    "outputs": [],
    "source": [
-    "from spectate import watched_type, Bunch"
+    "from spectate import expose_as, watch, Bunch"
    ]
   },
   {
@@ -44,7 +44,7 @@
    },
    "outputs": [],
    "source": [
-    "EventfulDict = watched_type('EventfulDict', dict, '__setitem__',\n",
+    "EventfulDict = expose_as('EventfulDict', dict, '__setitem__',\n",
     "    '__delitem__', 'setdefault', 'update', 'pop', 'popitem')"
    ]
   },
@@ -143,15 +143,15 @@
    },
    "outputs": [],
    "source": [
-    "edict = EventfulDict({'a': 1, 'b':2})\n",
+    "edict, spectator = watch(EventfulDict, {'a': 1, 'b':2})\n",
     "\n",
-    "edict.instance_spectator.callback(\n",
-    "    ('__setitem__', '__delitem__', 'pop',\n",
-    "     'setdefault'), before_item_change)\n",
     "\n",
-    "edict.instance_spectator.callback('popitem', before_popitem)\n",
+    "methods = ('__setitem__', '__delitem__', 'pop', 'setdefault')\n",
+    "spectator.callback(methods, before_item_change)\n",
     "\n",
-    "edict.instance_spectator.callback('update', before_update)"
+    "spectator.callback('popitem', before_popitem)\n",
+    "\n",
+    "spectator.callback('update', before_update)"
    ]
   },
   {
@@ -200,9 +200,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [conda root]",
    "language": "python",
-   "name": "python2"
+   "name": "conda-root-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -214,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,

--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -17,7 +17,7 @@
    },
    "outputs": [],
    "source": [
-    "from spectate import watched_type"
+    "from spectate import expose_as, watch"
    ]
   },
   {
@@ -39,7 +39,7 @@
    },
    "outputs": [],
    "source": [
-    "EventfulList = watched_type('EventfulList', list, '__setitem__', '__delitem__', 'pop')"
+    "EventfulList = expose_as('EventfulList', list, '__setitem__', '__delitem__', 'pop')"
    ]
   },
   {
@@ -129,9 +129,10 @@
     "\n",
     "# callback accepts a method name string or,\n",
     "# as in this case, a list or tuple of names\n",
-    "elist.instance_spectator.callback(methods,\n",
-    "        before=pass_on_old_value,\n",
-    "        after=print_element_change)"
+    "spectator = watch(elist)\n",
+    "spectator.callback(methods,\n",
+    "    before=pass_on_old_value,\n",
+    "    after=print_element_change)"
    ]
   },
   {
@@ -212,14 +213,23 @@
    "source": [
     "elist"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [conda root]",
    "language": "python",
-   "name": "python2"
+   "name": "conda-root-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -231,7 +241,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,

--- a/spectate/_version.py
+++ b/spectate/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 1, 0)
+version_info = (0, 2, 0)
 __version__ = '.'.join(map(str, version_info))

--- a/spectate/tests/test_spectate.py
+++ b/spectate/tests/test_spectate.py
@@ -1,98 +1,178 @@
 import inspect
-from ..spectate import watched_type, WatchedType, MethodSpectator, Spectator, Bunch
+from ..spectate import (expose, expose_as, watch, watcher,
+    unwatch, watchable, WatchableType, MethodSpectator,
+    Spectator, Bunch)
 
-def test_watched_type():
-	WatchedList = watched_type(
-		'WatchedList', list, 'append')
 
-	assert WatchedList.__name__ == 'WatchedList'
-	assert issubclass(WatchedList, list)
-	assert issubclass(WatchedList, WatchedType)
-	assert isinstance(WatchedList.append, MethodSpectator)
+def test_watchable():
+    assert watchable(WatchableType)
+    assert watchable(WatchableType())
 
-	wl = WatchedList()
-	assert hasattr(wl, 'instance_spectator')
-	assert isinstance(wl.instance_spectator, Spectator)
 
-def test_method_spectator():
-	MethodSpectator._compile_count = 0
-	WatchedList = watched_type(
-		'WatchedList', list, 'append')
-	assert MethodSpectator._compile_count == 1
-	append = WatchedList.append
+def test_expose():
+    WatchableList = expose(list, 'append', name="WatchableList")
 
-	assert append.basemethod is list.append
-	assert append.name == 'append'
-
-	wl = WatchedList()
-	wl.append(1)
-	wl.append(2)
-	assert wl == [1, 2]
-
-	class Thing(object):
-		def func(self, a, b, c=None, d=None, *e, **f):
-			pass
-
-	WatchedThing = watched_type('WatchedThing', Thing, 'func')
-	assert MethodSpectator._compile_count == 2
-	assert (inspect.getargspec(Thing().func) ==
-		inspect.getargspec(WatchedThing().func))
+    assert watchable(WatchableList)
+    assert issubclass(WatchableList, list)
+    assert WatchableList.__name__ == 'WatchableList'
+    assert isinstance(WatchableList.append, MethodSpectator)
 
 
 class Thing(object):
-	def func(inst, a, b, c=None, d=None, *e, **f):
-		return inst,  a, b, c, d, e, f
+        def func(self, a, b, c=None, d=None, *e, **f):
+            return (self, a, b, c, d, e, f)
+
+
+def test_watch():
+    WatchableThing = expose_as("WatchableThing", Thing, "func")
+    wt = WatchableThing()
+    spectator = watch(wt)
+
+    assert isinstance(spectator, Spectator)
+    assert hasattr(wt, "_instance_spectator")
+    assert wt._instance_spectator is spectator
+
+    WatchableList = expose_as("WatchableList", list, "append")
+    wl, spectator = watch(WatchableList, [1, 2, 3])
+
+    assert wl == [1, 2, 3]
+    assert isinstance(spectator, Spectator)
+    assert hasattr(wl, "_instance_spectator")
+    assert wl._instance_spectator is spectator
+
+
+def test_watcher():
+    WatchableThing = expose_as("WatchableThing", Thing, "func")
+    wt, spectator = watch(WatchableThing)
+    assert watcher(wt) is spectator
+
+
+def test_unwatch():
+    WatchableThing = expose_as("WatchableThing", Thing, "func")
+    wt, spectator = watch(WatchableThing)
+    out = unwatch(wt)
+    assert not hasattr(wt, "_instance_spectator")
+    assert out is spectator
+
+
+def test_method_spectator():
+    MethodSpectator._compile_count = 0
+    WatchableList = expose_as("WatchableList", list, 'append')
+    assert MethodSpectator._compile_count == 1
+    append = WatchableList.append
+
+    assert append.basemethod is list.append
+    assert append.name == 'append'
+
+    wl, spectator = watch(WatchableList)
+    wl.append(1)
+    wl.append(2)
+    assert wl == [1, 2]
+
+
+def test_method_spectator_argspec():
+    WatchableThing = expose_as("WatchableThing", Thing, 'func')
+    thing, sectator = watch(WatchableThing)
+    assert MethodSpectator._compile_count == 2
+    assert (inspect.getargspec(Thing().func) ==
+        inspect.getargspec(thing.func))
+
 
 def check_answer(checklist, inst, name, a, b, c=None, d=None, *e, **f):
-	args, kwargs = condense(a, b, c, d, *e, **f)
-	checklist.append(Bunch(
-		name=name,
-		value=(inst, a, b, c, d, e, f),
-		before=Bunch(
-			name=name,
-			args=args,
-			kwargs=kwargs))
-	)
-	getattr(inst, name)(a, b, c, d, *e, **f)
+    args, kwargs = condense(a, b, c, d, *e, **f)
+    checklist.append(Bunch(
+        name=name,
+        value=(inst, a, b, c, d, e, f),
+        before=Bunch(
+            name=name,
+            args=args,
+            kwargs=kwargs))
+    )
+    getattr(inst, name)(a, b, c, d, *e, **f)
+
 
 condense = lambda *a, **kw: (a, kw)
 
 
 def test_beforeback_afterback():
-	checklist = []
+    checklist = []
 
-	WatchedThing = watched_type('WatchedThing', Thing, 'func')
-	wt = WatchedThing()
+    WatchableThing = expose_as("WatchableThing", Thing, 'func')
+    wt = WatchableThing()
+    spectator = watch(wt)
 
-	# callback stores call information
-	def beforeback(inst, call):
-		return call
-	def afterback(inst, answer):
-		assert checklist[-1] == answer
+    callbacks_called = [0, 0]
 
-	wt.instance_spectator.callback('func',
-		before=beforeback, after=afterback)
+    # callback stores call information
+    def beforeback(inst, call):
+        callbacks_called[0] += 1
+        return call
+    def afterback(inst, answer):
+        callbacks_called[1] += 1
+        assert checklist[-1] == answer
 
-	check_answer(checklist, wt, 'func', 1, 2, c=3)
-	check_answer(checklist, wt, 'func', 1, 2, d=3)
-	check_answer(checklist, wt, 'func', 1, 2, 3, 4, 5)
-	check_answer(checklist, wt, 'func', 1, 2, d=3, f=4)
+    spectator.callback('func',
+        before=beforeback, after=afterback)
+
+    check_answer(checklist, wt, 'func', 1, 2, c=3)
+    check_answer(checklist, wt, 'func', 1, 2, d=3)
+    check_answer(checklist, wt, 'func', 1, 2, 3, 4, 5)
+    check_answer(checklist, wt, 'func', 1, 2, d=3, f=4)
+    assert callbacks_called == [4, 4]
+
 
 def test_callback_closure():
-	checklist = []
+    checklist = []
 
-	WatchedThing = watched_type('WatchedThing', Thing, 'func')
-	wt = WatchedThing()
+    WatchableThing = expose_as("WatchableThing", Thing, 'func')
+    wt = WatchableThing()
+    spectator = watch(wt)
 
-	def callback(inst, call):
-		def closure(value):
-			assert (checklist[-1] == Bunch(
-				name=call.name, value=value,
-				before=call))
+    callbacks_called = [0, 0]
 
-	wt.instance_spectator.callback('func', callback)
+    def callback(inst, call):
+        callbacks_called[0] += 1
+        def closure(value):
+            callbacks_called[1] += 1
+            print(checklist[-1])
+            print("-----")
+            print(Bunch(
+                name=call.name, value=value,
+                before=call))
 
-	check_answer(checklist, wt, 'func', 1, 2, c=3)
-	check_answer(checklist, wt, 'func', 1, 2, d=3)
-	check_answer(checklist, wt, 'func', 1, 2, 3, 4, 5)
-	check_answer(checklist, wt, 'func', 1, 2, d=3, f=4)
+            assert (checklist[-1] == Bunch(
+                name=call.name, value=value,
+                before=call))
+        return closure
+
+    spectator.callback('func', callback)
+
+    check_answer(checklist, wt, 'func', 1, 2, c=3)
+    check_answer(checklist, wt, 'func', 1, 2, d=3)
+    check_answer(checklist, wt, 'func', 1, 2, 3, 4, 5)
+    check_answer(checklist, wt, 'func', 1, 2, d=3, f=4)
+    assert callbacks_called == [4, 4]
+
+
+def test_callback_multiple():
+
+    class Test(object):
+        def a(self):
+            pass
+        def b(self):
+            pass
+
+    WatchableTest = expose(Test, "a", "b")
+    wt, spectator = watch(WatchableTest)
+
+    callback = lambda value, call: None
+
+    spectator.callback(("a", "b"), callback)
+
+    for key in ("a", "b"):
+        assert key in spectator._callback_registry
+        assert spectator._callback_registry[key] == [(callback, None)]
+
+    spectator.remove_callback(("a", "b"), callback)
+
+    assert spectator._callback_registry == {}


### PR DESCRIPTION
Instead of `watched_type` the methods `expose` and `watch` are introduced.

See updated examples for new uses.

Version also bumped to 0.2.0