### PR TITLE
Model View Controller Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docs/_build/
 target/
 
 .ipynb_checkpoints
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - pip install -r requirements.txt
 # command to run tests
 script:
-  - py.test spectate
+  - py.test .
 
 notifications:
   email:

--- a/examples/advanced.ipynb
+++ b/examples/advanced.ipynb
@@ -139,9 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "edict, spectator = watched(EventfulDict, {'a': 1, 'b':2})\n",
@@ -157,9 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -200,9 +196,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda root]",
+   "display_name": "Python (Py3)",
    "language": "python",
-   "name": "conda-root-py"
+   "name": "py3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -214,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use `expose_as` to create a `WatchableType` called `EventfulList` with methods that are exposed to callbacks. The signature of `expose_as` requries the `name` of the new eventful type, a `base` class from which that new type should inherit, and the series of `methods` on that base class which can register a callback. In this case we enable callbacks for methods which can set or delete items:\n",
+    "We use `expose_as` to create a `Watchable` called `EventfulList` with methods that are exposed to callbacks. The signature of `expose_as` requries the `name` of the new eventful type, a `base` class from which that new type should inherit, and the series of `methods` on that base class which can register a callback. In this case we enable callbacks for methods which can set or delete items:\n",
     "\n",
     "+ `__setitem__`\n",
     "+ `__delitem__`\n",
@@ -34,9 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "EventfulList = expose_as('EventfulList', list, '__setitem__', '__delitem__', 'pop')"
@@ -49,15 +47,13 @@
     "# Creating Spectators\n",
     "\n",
     "In order to register callbacks to an eventful object, you need to create a `Spectator` that will `watch` it for you.\n",
-    "A `Spectator` is a relatively simple object that has methods for adding, deleting, and triggering callbacks. To create a spectator we call `spectator = watch(x)`, where `x` is a `WatchableType`:"
+    "A `Spectator` is a relatively simple object that has methods for adding, deleting, and triggering callbacks. To create a spectator we call `spectator = watch(x)`, where `x` is a `Watchable`:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "elist = EventfulList([1, 2, 3])\n",
@@ -85,11 +81,7 @@
     "        + ``'kwargs'`` - the keywords which that method will call\n",
     "\n",
     "+ Can ``return`` a value which gets passed on to its respective afterback.\n",
-    "+ If an error is encountered, the wrapper will ``return`` the original ``call``\n",
-    "as if it were that of the beforeback, and set ``error`` in the ``answer``\n",
-    "bunch of its afterback. This way, if the base method call is valid, it's not\n",
-    "obstructed by a raised beforeback. Thus, beforeback errors should be handled\n",
-    "in an afterback.\n",
+    "\n",
     "\n",
     "## Afterbacks\n",
     "\n",
@@ -108,9 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# beforeback\n",
@@ -136,9 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "methods = ('pop', '__delitem__', '__setitem__')\n",
@@ -154,9 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# does not notify because\n",
@@ -167,9 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -188,9 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -211,9 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -243,9 +223,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda root]",
+   "display_name": "Python (Py3)",
    "language": "python",
-   "name": "conda-root-py"
+   "name": "py3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -257,7 +237,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,12 @@
+# -------------
+# Documentation
+# -------------
+
+sphinxcontrib-napoleon
+sphinx_materialdesign_theme
+
+# -------
+# Testing
+# -------
+
 pytest
-six

--- a/setup.py
+++ b/setup.py
@@ -30,49 +30,40 @@ root = os.path.join(here, name)
 
 packages = find_packages()
 
+
+requirements = [
+    'six',
+]
+
+
 with open(os.path.join(root, '_version.py')) as f:
     namespace = {}
     exec(f.read(), {}, namespace)
     version = namespace["__version__"]
 
-long_description = """
-Spectate
-========
-Create classes whose instances have tracked methods
 
-``spectate`` is useful for remotely tracking how an instance is modified. This means that protocols
-for managing updates, don't need to be the outward responsibility of a user, and can instead be
-done automagically in the background.
+with open(os.path.join(here, 'README.md')) as f:
+    long_description = f.read()
 
-For example, if it were desirable to keep track of element changes in a list, ``spectate`` could be
-used to observe ``list.__setitiem__`` in order to be notified when a user sets the value of an element
-in the list. To do this, we would first create an ``elist`` type using ``expose_as``, construct an
-instance of that type, and then store callback pairs to that instance's spectator. To access a spectator,
-register one with ``watch`` (e.g. ``spectator = watch(the_elist)``), retrieve a preexisting one with the
-``watcher`` function. Callback pairs are stored by calling the ``watcher(the_list).callback`` method. You
-can then specify, with keywords, whether the callback should be triggered ``before``, and/or or ``after``
-a given method is called - hereafter refered to as "beforebacks" and "afterbacks" respectively.
-"""
-
-setup_args = dict(
-	name = name,
-    version = version,
-    packages = packages,
-    description = "Create classes whose instances have tracked methods",
-    long_description = long_description,
-    author = "Ryan Morshead",
-    author_email = "ryan.morshead@gmail.com",
-    url = "https://github.com/rmorshea/spectate",
-    license = 'MIT',
-    platforms = "Linux, Mac OS X, Windows",
-    keywords = ["eventful", "callbacks"],
-    classifiers = [
-        'Intended Audience :: Developers',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        ],
-)
 
 if __name__ == '__main__':
-    setup(**setup_args)
+    setup(
+        name=name,
+        version=version,
+        packages=packages,
+        description="Create classes whose instances have tracked methods",
+        long_description=long_description,
+        author="Ryan Morshead",
+        author_email="ryan.morshead@gmail.com",
+        url="https://github.com/rmorshea/spectate",
+        license='MIT',
+        platforms="Linux, Mac OS X, Windows",
+        keywords=["eventful", "callbacks"],
+        install_requires=requirements,
+        classifiers=[
+            'Intended Audience :: Developers',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3.3',
+            ],
+    )

--- a/spectate/_version.py
+++ b/spectate/_version.py
@@ -1,2 +1,2 @@
-info = (0, 1, 0,)
+info = (0, 2, 0,)
 __version__ = '.'.join(map(str, info))

--- a/spectate/mvc/__init__.py
+++ b/spectate/mvc/__init__.py
@@ -1,0 +1,9 @@
+import sys
+
+if sys.version_info < (3, 6):
+    raise RuntimeError('Python 3.6 or greater required.')
+else:
+    del sys
+
+from .base import *
+from .models import *

--- a/spectate/mvc/base.py
+++ b/spectate/mvc/base.py
@@ -1,0 +1,150 @@
+# See End Of File For Licensing
+
+from functools import wraps, partial
+
+from .utils import completemethod
+from ..spectate import Watchable, Bunch, MethodSpectator, expose, watched
+
+__all__ = [
+    'Model',
+    'is_model',
+    'control',
+    'view',
+    'unview',
+]
+
+
+def is_model(x):
+    return isinstance(x, Model)
+
+
+def view(model, select=None):
+    if not is_model(model):
+        raise TypeError('Expected a Model, not %r.' % model)
+    def setup(function):
+        if select:
+            @wraps(function)
+            def wrapper(event):
+                if select(event):
+                    return function(event)
+            model._model_views.append(wrapper)
+            return wrapper
+        else:
+            model._model_views.append(function)
+            return function
+    return setup
+
+
+def unview(model, function):
+    model._model_views.remove(function)
+
+
+class control:
+
+    @staticmethod
+    def _before(self, call, notify):
+        return call
+
+    _after = None
+
+    @staticmethod
+    def _wrap(function):
+        if function is None:
+            return None
+        @wraps(function)
+        def callback(self, *args, **kwargs):
+            def notify(*args, **kwargs):
+                event = Bunch(*args, **kwargs)
+                self._notify_model_views(event)
+            return function(self, *(args + (notify,)), **kwargs)
+        return callback
+
+    @completemethod
+    def before(cls, *methods):
+        new = super().__new__
+        def setup(callback):
+            self = new(cls)
+            self.methods = methods
+            self._before = callback
+            return self
+        return setup
+
+    @before
+    def before(self, callback):
+        if isinstance(callback, control):
+            callback = callback._before
+        self._before = callback
+        return self
+
+    @completemethod
+    def after(cls, *methods):
+        new = super().__new__
+        def setup(callback):
+            self = new(cls)
+            self.methods = methods
+            self._after = callback
+            return self
+        return setup
+
+    @after
+    def after(self, callback):
+        if isinstance(callback, control):
+            callback = callback._after
+        self._after = callback
+        return self
+
+    def __set_name__(self, cls, name):
+        if not issubclass(cls, Model):
+            raise TypeError("Can only define a control on a Model, not %r" % cls)
+        for m in self.methods:
+            setattr(cls, m, MethodSpectator(getattr(cls, m), m))
+
+
+class Model(Watchable):
+
+    _model_controls = ()
+
+    def __init_subclass__(cls, **kwargs):
+        for k, v in list(cls.__dict__.items()):
+            if isinstance(v, control):
+                cls._model_controls += (k,)
+        super().__init_subclass__(**kwargs)
+
+    def __new__(cls, *args, **kwargs):
+        self, spectator = watched(super().__new__, cls)
+        for name in cls._model_controls:
+            ctrl = getattr(cls, name)
+            for method in ctrl.methods:
+                before = ctrl._wrap(ctrl._before)
+                after= ctrl._wrap(ctrl._after)
+                spectator.callback(method, before, after)
+        self._model_views = []
+        self.__init__(*args, **kwargs)
+        return self
+
+    def _notify_model_views(self, event):
+        for v in self._model_views:
+            v(event)
+
+
+# The MIT License (MIT)
+
+# Copyright (c) 2016 Ryan S. Morshead
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/spectate/mvc/models.py
+++ b/spectate/mvc/models.py
@@ -1,0 +1,197 @@
+# See End Of File For Licensing
+
+from .utils import Sentinel
+from .base import Model, control
+
+
+__all__ = [
+    'List',
+    'Dict',
+    'Set',
+    'Undefined',
+]
+
+
+Undefined = Sentinel('Undefined')
+
+
+class List(Model, list):
+
+    @control.before('__setitem__')
+    def _control_setitem(self, call, notify):
+        index = call.args[0]
+        try:
+            old = self[index]
+        except KeyError:
+            old = Undefined
+        return index, old
+
+    @_control_setitem.after
+    def _control_setitem(self, answer, notify):
+        index, old = answer.before
+        new = self[index]
+        if new is not old:
+            notify(index=index, old=old, new=new)
+
+    @control.before('__delitem__')
+    def _control_delitem(self, call, notify):
+        index = call.args[0]
+        return index, self[index:]
+
+    @_control_delitem.after
+    def _control_delitem(self, answer, notify):
+        index, old = answer.before
+        for i, x in enumerate(old):
+            try:
+                new = self[index + i]
+            except IndexError:
+                new = Undefined
+            notify(index=(i + index), old=x, new=new)
+
+    @control.before('insert')
+    def _control_insert(self, call, notify):
+        index = call.args[0]
+        return index, self[index:]
+
+    @_control_insert.after
+    def _control_insert(self, answer, notify):
+        index, old = answer.before
+        for i in range(index, len(self)):
+            try:
+                o = old[i]
+            except IndexError:
+                o = Undefined
+            notify(index=i, old=o, new=self[i])
+
+    @control.after('append')
+    def _control_append(self, answer, notify):
+        notify(index=len(self) - 1, old=Undefined, new=self[-1])
+
+    @control.before('extend')
+    def _control_extend(self, call, notify):
+        return len(self)
+
+    @_control_extend.after
+    def _control_extend(self, answer, notify):
+        for i in range(answer.before, len(self)):
+            notify(index=i, old=Undefined, new=self[i])
+
+    @control.before('remove')
+    def _control_remove(self, call, notify):
+        index = self.index(call.args[0])
+        return index, self[index:]
+
+    _control_remove.after(_control_delitem)
+
+    @control.before('reverse')
+    def _before_reverse(self, call, notify):
+        return self._control_rearrangement(self)
+
+    @control.before('sort')
+    def _before_sort(self, call, notify):
+        return self._control_rearrangement(self)
+
+    @staticmethod
+    def _control_rearrangement(new):
+        old = new[:]
+        def _after_rearangement(returned, notify):
+            for i, v in enumerate(old):
+                if v != new[i]:
+                    notify(index=i, old=v, new=new[i])
+        return _after_rearangement
+
+
+class Dict(Model, dict):
+
+    @control.before('__setitem__', 'setdefault')
+    def _control_setitem(self, call, notify):
+        key = call.args[0]
+        old = self.get(key, Undefined)
+        return key, old
+
+    @_control_setitem.after
+    def _control_setitem(self, answer, notify):
+        key, old = answer.before
+        new = self[key]
+        if new != old:
+            notify(key=key, old=old, new=new)
+
+    @control.before('__delitem__', 'pop')
+    def _control_delitem(self, call, notify):
+        key = call.args[0]
+        try:
+            old = self[key]
+        except KeyError:
+            pass
+        else:
+            def _after(returned):
+                notify(key=key, old=old, new=Undefined)
+            return _after
+
+    @control.before('update')
+    def _control_update(self, call, notify):
+        if len(call.args):
+            args = call.args[0]
+            if inspect.isgenerator(arg):
+                # copy generator so it doesn't get exhausted
+                arg = itertools.tee(arg)[1]
+            new = dict(arg)
+            new.update(call.kwargs)
+        else:
+            new = call.kwargs
+        old = {k: self.get(k, Undefined) for k in new}
+        return old
+
+    @_control_update.after
+    def _control_update(self, answer, notify):
+        for k, v in answer.before.items():
+            if self[k] != v:
+                notify(key=k, old=v, new=self[k])
+
+    @control.before('clear')
+    def _control_clear(self, call, notify):
+        return self.copy()
+
+    @_control_clear.after
+    def _control_clear(self, answer, notify):
+        for k, v in answer.before.items():
+            notify(key=k, old=v, new=Undefined)
+
+
+class Set(Model, set):
+
+    @control.before(
+        "clear", "update", "difference_update", "intersection_update",
+        "add", "pop", "remove", "symmetric_difference_update", "discard")
+    def _control_update(self, call, notify):
+        return self.copy()
+
+    @_control_update.after
+    def _control_update(self, answer, notify):
+        new = self.difference(answer.before)
+        old = answer.before.difference(self)
+        if new or old:
+            notify(new=new, old=old)
+
+
+# The MIT License (MIT)
+
+# Copyright (c) 2016 Ryan S. Morshead
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/spectate/mvc/utils.py
+++ b/spectate/mvc/utils.py
@@ -1,0 +1,35 @@
+import types
+
+
+class Sentinel:
+
+    def __init__(self, name):
+        self.__name = name
+
+    def __repr__(self):
+        return self.__name
+
+
+class completemethod:
+
+    _class_method = None
+    _instance_method = None
+
+    def __init__(self, function):
+        self._class_method = function
+
+    def __call__(self, function):
+        self._instance_method = function
+        return self
+
+    def __set_name__(self, cls, name):
+        if self._class_method is None:
+            raise TypeError('No class method defined.')
+        elif self._instance_method is None:
+            raise TypeError('No instance method defined.')
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return types.MethodType(self._class_method, cls)
+        else:
+            return types.MethodType(self._instance_method, obj)

--- a/tests/test_spectate.py
+++ b/tests/test_spectate.py
@@ -1,6 +1,6 @@
 import sys
 import inspect
-from spectate import (
+from spectate.spectate import (
     expose, expose_as, watch, watched,
     watcher, unwatch, watchable, Watchable,
     MethodSpectator, Spectator, Bunch,

--- a/tests/test_spectate.py
+++ b/tests/test_spectate.py
@@ -1,11 +1,31 @@
+import sys
 import inspect
-from ..spectate import (expose_as, watch, watched, watcher, unwatch,
-    watchable, WatchableType, MethodSpectator, Spectator, Bunch)
+from spectate import (
+    expose, expose_as, watch, watched,
+    watcher, unwatch, watchable, Watchable,
+    MethodSpectator, Spectator, Bunch,
+)
 
 
 def test_watchable():
-    assert watchable(WatchableType)
-    assert watchable(WatchableType())
+    assert watchable(Watchable)
+    assert watchable(Watchable())
+
+
+def test_expose():
+
+    @expose('increment')
+    class Counter(object):
+
+        def __init__(self):
+            self.x = 0
+
+        def increment(self, amount=1):
+            self.x += amount
+
+    assert watchable(Counter)
+    assert Counter.__name__ == 'Counter'
+    assert isinstance(Counter.increment, MethodSpectator)
 
 
 def test_expose_as():
@@ -183,3 +203,22 @@ def test_callback_multiple():
     spectator.remove_callback(("a", "b"), callback)
 
     assert spectator._callback_registry == {}
+
+
+if not sys.version_info < (3, 6):
+
+    def test_subclass_override():
+
+        @expose('method')
+        class Parent:
+
+            def method(self):
+                pass
+
+        class Child(Parent):
+
+            def method(self):
+                pass
+
+        assert watchable(Child)
+        assert isinstance(Child.method, MethodSpectator)


### PR DESCRIPTION
This update includes various minor changes, but is primarily focused on `spectate.mvc` which, if you're using Python 3.6 or greater, provides an experimental Model-View-Controller (MVC) framework. Out of the box `spectate.mvc` has three basic model types for `list`, `dict`, and `set` (Python's three mutable built-in types):


```python
from spectate import mvc


d = mvc.Dict()
l = mvc.List()
s = mvc.Set()


@mvc.view(d)
@mvc.view(l)
@mvc.view(s)
def printer(event):
    print(event)


d['a'] = 1
l.append(2)
s.add(3)
```

```
{'key': 'a', 'old': Undefined, 'new': 1}
{'index': 0, 'old': Undefined, 'new': 2}
{'new': {3}, 'old': set()}
```


For most users these built-in types should be enough, however if you're adventurous, then you can define your own `mvc.Model`:


```python
from spectate import mvc


class Counter(mvc.Model):

    def __init__(self):
        self.x = 0

    def increment(self, amount):
        self.x += amount

    def decrement(self, amount):
        self.x -= amount

    # define a beforeback for increment and decrement
    @mvc.control.before('increment', 'decrement')
    def _control_change(self, call, notify):
        return self.x

    # create the corresponding afterback
    @_control_change.after
    def _control_change(self, answer, notify):
        # Send an "event" dictionary to the Counter's views.
        notify(old=answer.before, new=self.x)
```


Once we've defined our `Model` and its `control` methods, we can then use `mvc.view` as we saw above with `List`, `Dict`, and `Set`:


```python
counter = Counter()


@mvc.view(counter)
def printer(event):
    print(event)


counter.increment(1)
counter.decrement(2)
counter.increment(3)
counter.decrement(4)
```

```
{'old': 0, 'new': 1}
{'old': 1, 'new': -1}
{'old': -1, 'new': 2}
{'old': 2, 'new': -2}
```
