### PR TITLE
add contexts for hold & mute, add controlled pop to List

### DIFF
--- a/spectate/__init__.py
+++ b/spectate/__init__.py
@@ -12,3 +12,4 @@ Spectate
 """
 
 from .spectate import *
+from ._version import __version__

--- a/spectate/mvc/__init__.py
+++ b/spectate/mvc/__init__.py
@@ -7,6 +7,9 @@ MVC
 
 .. automodule:: spectate.mvc.models
     :members:
+
+.. automodule:: spectate.mvc.utils
+    :members:
 """
 
 import sys

--- a/spectate/mvc/__init__.py
+++ b/spectate/mvc/__init__.py
@@ -15,7 +15,7 @@ MVC
 import sys
 
 if sys.version_info < (3, 6):
-    raise RuntimeError('Python 3.6 or greater required.')
+    raise ImportError('Python 3.6 or greater required.')
 else:
     del sys
 

--- a/spectate/mvc/base.py
+++ b/spectate/mvc/base.py
@@ -1,9 +1,10 @@
 # See End Of File For Licensing
 
 from contextlib import contextmanager
-from functools import wraps, partial
+from functools import wraps
+from collections import defaultdict
 
-from .utils import completemethod
+from .utils import completemethod, memory_safe_function
 from ..spectate import Watchable, Data, MethodSpectator, expose, watched
 
 __all__ = [
@@ -57,25 +58,38 @@ def mute(model):
             model._notify_model_views = restore
 
 
-def view(model, select=None):
+def views(model):
     if not is_model(model):
-        raise TypeError('Expected a Model, not %r.' % model)
+        raise TypeError('%r is not a Model.' % model)
+    return {s : l[:] for s, l in model._model_views.items()}
+
+
+def view(*models, **select):
     def setup(function):
-        if select:
-            @wraps(function)
-            def wrapper(event):
-                if select(event):
-                    return function(event)
-            model._model_views.append(wrapper)
-            return wrapper
-        else:
-            model._model_views.append(function)
-            return function
+        # we want to avoid circular references.
+        safe = memory_safe_function(function)
+        for model in models:
+            if not is_model(model):
+                raise TypeError('%r is not a Model.' % model)
+            if not select:
+                model._model_views[None].append(safe)
+            else:
+                selector = model._model_event_selector.format(**select)
+                model._model_views[selector].append(safe)
+        return safe
     return setup
 
 
-def unview(model, function):
-    model._model_views.remove(function)
+def unview(*models, **select):
+    def setup(function):
+        for model in models:
+            if not is_model(model):
+                raise TypeError('%r is not a Model.' % model)
+            if select:
+                selector = model._model_event_selector.format(**select)
+            else:
+                selector = None
+            model._model_views[selector].remove(function)
 
 
 class control:
@@ -142,6 +156,7 @@ class control:
 class Model(Watchable):
 
     _model_controls = ()
+    _model_event_selector = ''
 
     def __init_subclass__(cls, **kwargs):
         for k, v in list(cls.__dict__.items()):
@@ -157,13 +172,17 @@ class Model(Watchable):
                 before = ctrl._wrap(ctrl._before)
                 after= ctrl._wrap(ctrl._after)
                 spectator.callback(method, before, after)
-        self._model_views = []
+        self._model_views = defaultdict(list)
         self.__init__(*args, **kwargs)
         return self
 
     def _notify_model_views(self, event):
-        for v in self._model_views:
-            v(event)
+        selector = self._model_event_selector.format(**event)
+        event = event['model': self]
+        for view in self._model_views[selector]:
+            view(event)
+        for view in self._model_views[None]:
+            view(event)
 
 
 # The MIT License (MIT)

--- a/spectate/mvc/base.py
+++ b/spectate/mvc/base.py
@@ -178,7 +178,6 @@ class Model(Watchable):
 
     def _notify_model_views(self, event):
         selector = self._model_event_selector.format(**event)
-        event = event['model': self]
         for view in self._model_views[selector]:
             view(event)
         for view in self._model_views[None]:

--- a/spectate/mvc/models.py
+++ b/spectate/mvc/models.py
@@ -77,6 +77,10 @@ class List(Model, list):
         for i in range(answer.before, len(self)):
             notify(index=i, old=Undefined, new=self[i])
 
+    @control.after('pop')
+    def _control_pop(self, answer, notify):
+        notify(index=len(self), old=answer.value, new=Undefined)
+
     @control.before('remove')
     def _control_remove(self, call, notify):
         index = self.index(call.args[0])

--- a/spectate/mvc/models.py
+++ b/spectate/mvc/models.py
@@ -109,6 +109,8 @@ class List(Model, list):
 class Dict(Model, dict):
     """An MVC enabled ``dict``."""
 
+    _model_selector_template = '{key}'
+
     @control.before('__setitem__', 'setdefault')
     def _control_setitem(self, call, notify):
         key = call.args[0]

--- a/spectate/mvc/utils.py
+++ b/spectate/mvc/utils.py
@@ -37,21 +37,18 @@ class completemethod:
 
 
 def memory_safe_function(function):
-    """Return a function which has no outside references.
+    """Return a memory safe copy of a function.
 
-    All the defauts, and closure of this function are turned into proxy objects
-    wherever possible. This creates a "memory safe" function (with the exception
-    of global variables).
+    Through some clever tricks, all the defauts, and closure of this function
+    are turned into proxy objects wherever possible. **Making a function memory
+    safe may require its parent scope to be modified** - if the function contains
+    a ``list``, ``dict``, or ``set`` in its closure or default arguments, all
+    values contained in those data structures will be converted to proxy objects!
 
     Parameters
     ----------
     function: FunctionType, MethodType
-        Only functions are allowed.
-
-    Returns
-    -------
-    ghost: FunctionType
-        A copy of the given function that is "memory safe".
+        The function to be made into a memory safe copy.
     """
     if isinstance(function, types.MethodType):
         self = as_proxy(function.__self__)
@@ -66,7 +63,7 @@ def memory_safe_function(function):
 
     safe = types.FunctionType(
         function.__code__,
-        function.__globals__, # globals are NOT safe.
+        function.__globals__,
         function.__name__,
         defaults,
         closure)

--- a/spectate/spectate.py
+++ b/spectate/spectate.py
@@ -394,6 +394,8 @@ class Data(collections.Mapping):
             else:
                 new = {s.start : s.stop for s in key}
                 return type(self)(self, **new)
+        if isinstance(key, collections.Mapping):
+            return type(self)(self, **key)
         return self.__dict__.get(key)
 
     def __setitem__(self, key, value):

--- a/tests/test_mvc.py
+++ b/tests/test_mvc.py
@@ -2,7 +2,7 @@ import sys
 from pytest import importorskip
 
 # skips for python 3.6 or less
-from spectate import mvc
+mvc = importorskip('spectate.mvc')
 
 
 def test_mvc_custom_model():

--- a/tests/test_mvc.py
+++ b/tests/test_mvc.py
@@ -1,0 +1,70 @@
+import sys
+from pytest import importorskip
+
+# skips for python 3.6 or less
+from spectate import mvc
+
+
+def test_mvc_custom_model():
+
+    class Counter(mvc.Model):
+
+        def __init__(self):
+            self.x = 0
+
+        def increment(self, amount):
+            self.x += amount
+
+        def decrement(self, amount):
+            self.x -= amount
+
+        # define a beforeback for increment and decrement
+        @mvc.control.before('increment', 'decrement')
+        def _control_change(self, call, notify):
+            return self.x
+
+        # create the corresponding afterback
+        @_control_change.after
+        def _control_change(self, answer, notify):
+            # Send an "event" dictionary to the Counter's views.
+            notify(old=answer.before, new=self.x)
+
+    counter = Counter()
+    events = []
+
+    @mvc.view(counter)
+    def printer(e):
+        events.append(e)
+
+    counter.increment(1)
+    counter.decrement(2)
+    counter.increment(3)
+    counter.decrement(4)
+
+    assert events == [
+        {'old': 0, 'new': 1},
+        {'old': 1, 'new': -1},
+        {'old': -1, 'new': 2},
+        {'old': 2, 'new': -2},
+    ]
+
+
+def test_view_memory_safety():
+
+    l = mvc.List()
+
+    @mvc.view(l)
+    def closure(event):
+        # adds `l` to __closure__
+        x = l
+
+    @mvc.view(l)
+    def defaults(event, l=l):
+        # adds `l` to defaults
+        x = l
+
+    # Both of the above callbacks would normally create cirular
+    # references, however mvc.utils.memory_safe_function will
+    # mitigate this magically for the user.
+
+    assert sys.getrefcount(l) == 2

--- a/tests/test_spectate.py
+++ b/tests/test_spectate.py
@@ -1,9 +1,10 @@
 import sys
 import inspect
+from pytest import raises
 from spectate.spectate import (
     expose, expose_as, watch, watched,
     watcher, unwatch, watchable, Watchable,
-    MethodSpectator, Spectator, Bunch,
+    MethodSpectator, Spectator, Data,
 )
 
 
@@ -111,10 +112,10 @@ def test_method_spectator_argspec():
 
 def check_answer(checklist, inst, name, a, b, c=None, d=None, *e, **f):
     args, kwargs = condense(a, b, c, d, *e, **f)
-    checklist.append(Bunch(
+    checklist.append(Data(
         name=name,
         value=(inst, a, b, c, d, e, f),
-        before=Bunch(
+        before=Data(
             name=name,
             args=args,
             kwargs=kwargs))
@@ -165,7 +166,7 @@ def test_callback_closure():
         callbacks_called[0] += 1
         def closure(value):
             callbacks_called[1] += 1
-            assert (checklist[-1] == Bunch(
+            assert (checklist[-1] == Data(
                 name=call.name, value=value,
                 before=call))
         return closure
@@ -222,3 +223,40 @@ if not sys.version_info < (3, 6):
 
         assert watchable(Child)
         assert isinstance(Child.method, MethodSpectator)
+
+
+def test_data_is_immutable():
+    d = Data(a=0)
+    with raises(TypeError):
+        d['a'] = 1
+    with raises(TypeError):
+        d.a = 1
+    with raises(TypeError):
+        del d['a']
+    with raises(TypeError):
+        del d.a
+    assert d == {'a': 0}
+
+
+def test_none_is_empty_data():
+    d = Data(a=None)
+    assert d == {}
+    assert 'b' not in d
+    assert d['a'] is None
+
+
+def test_data_evolution():
+    d0 = Data(a=0)
+
+    d1 = d0['b': 1]
+    assert d1 == {'a': 0, 'b': 1}
+
+    d2 = d1['b': 2, 'c': 3]
+    assert d2 == {'a': 0, 'b': 2, 'c': 3}
+
+    d3 = d2['b': None, 'c': None]
+    assert d3 == d0
+
+def test_data_is_mapping():
+    assert dict(Data(a=0, b=1)) == {'a': 0, 'b': 1}
+    assert dict(**Data(a=0, b=1)) == {'a': 0, 'b': 1}

--- a/tests/test_spectate.py
+++ b/tests/test_spectate.py
@@ -247,15 +247,15 @@ def test_none_is_empty_data():
 
 def test_data_evolution():
     d0 = Data(a=0)
-
     d1 = d0['b': 1]
     assert d1 == {'a': 0, 'b': 1}
-
     d2 = d1['b': 2, 'c': 3]
     assert d2 == {'a': 0, 'b': 2, 'c': 3}
-
-    d3 = d2['b': None, 'c': None]
-    assert d3 == d0
+    d3 = d2[{'b': 3, 'c': 4}]
+    d4 = d3['b': None, 'c': None]
+    assert d4 == d0
+    d5 = d4[{'a': None}]
+    assert d5 == {}
 
 def test_data_is_mapping():
     assert dict(Data(a=0, b=1)) == {'a': 0, 'b': 1}


### PR DESCRIPTION
# Memory Leaks

The **number one** fix here has to do with memory safety. Unfortunately, `spectate` by it's nature makes it very easy to create circular reference if the user isn't paying attention. To resolve this the `spectate.mvc.view` decorator uses `spectate.mvc.utils.memory_safe_function` to create a copy of the given callback that uses `weakref.proxy` objects in its closure and default values.

# Mute and Hold

`hold` will collect all events that occur in the context and append them to a list which it yields. At the end of the context, all events in the list will be distributed. However because the list is yielded to the user, they can modify the contents of this list as they please.

`mute` simply suppresses all event notifications.

# Misc

Event data is immutable.

+ `Bunch` has become `Data`.
+ There's some clever syntax here as well:
  + `new = old['a': 1]` where `new` is a copy of `old` but with the key `a` set to `1`
  + To do the same thing programmatically use a dict instead `new = old[{'a': 1}]`

`List.pop` was not controlled.

# Upcoming Work

Begin to test the mvc framework now the memory leaks are fixed.