### PR TITLE
Tests, Docs, Slight API Change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pip install . -r requirements.txt
 script:
   # command to run tests
-  - py.test --cov --doctest-modules
+  - python -m pytest --cov --doctest-ignore-import-error
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,14 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "nightly" # currently points to 3.6-dev
-# command to install dependencies
+  - "3.6"
+  - "nightly"
 install:
-  - pip install .
-  - pip install -r requirements.txt
-# command to run tests
+  # command to install dependencies
+  - pip install . -r requirements.txt
 script:
-  - py.test .
-
+  # command to run tests
+  - py.test --cov --doctest-modules
 notifications:
   email:
     on_success: change

--- a/README.md
+++ b/README.md
@@ -185,12 +185,15 @@ class Counter(mvc.Model):
     def decrement(self, amount):
         self.x -= amount
 
-    # define a beforeback for increment and decrement
-    @mvc.control.before('increment', 'decrement')
+    # define a control for incrementing and decrementing
+    _control_change = mvc.Control('increment', 'decrement')
+
+    # register a beforeback to the control
+    @_control_change.before
     def _control_change(self, call, notify):
         return self.x
 
-    # create the corresponding afterback
+    # register an afterback to the control
     @_control_change.after
     def _control_change(self, answer, notify):
         # Send an "event" dictionary to the Counter's views.

--- a/docs/source/sections/api.rst
+++ b/docs/source/sections/api.rst
@@ -1,5 +1,7 @@
 API
 ===
 
+Raw source code documentation.
+
 .. automodule:: spectate
     :members:

--- a/examples/advanced.py
+++ b/examples/advanced.py
@@ -2,7 +2,7 @@ from spectate import expose, watch
 
 
 @expose('__setattr__', '__delattr__')
-class Data:
+class Data(object):
 
     def __init__(self):
         self._callbacks = []

--- a/examples/mvc/__init__.py
+++ b/examples/mvc/__init__.py
@@ -1,0 +1,6 @@
+import sys
+
+if sys.version_info < (3, 6):
+    raise ImportError('Python 3.6 or greater required.')
+else:
+    del sys

--- a/examples/mvc/advanced.py
+++ b/examples/mvc/advanced.py
@@ -12,12 +12,15 @@ class Counter(mvc.Model):
     def decrement(self, amount):
         self.x -= amount
 
-    # define a beforeback for increment and decrement
-    @mvc.control.before('increment', 'decrement')
+    # define a control for incrementing and decrementing
+    _control_change = mvc.Control('increment', 'decrement')
+
+    # register a beforeback to the control
+    @_control_change.before
     def _control_change(self, call, notify):
         return self.x
 
-    # create the corresponding afterback
+    # register an afterback to the control
     @_control_change.after
     def _control_change(self, answer, notify):
         # Send an "event" dictionary to the Counter's views.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sphinx_materialdesign_theme
 # -------
 
 pytest
+pytest-cov

--- a/spectate/__init__.py
+++ b/spectate/__init__.py
@@ -6,6 +6,7 @@ Spectate
 
 .. automodule:: spectate.spectate
     :members:
+    :ignore-module-all:
 
 .. automodule:: spectate.mvc
     :members:

--- a/spectate/mvc/__init__.py
+++ b/spectate/mvc/__init__.py
@@ -4,9 +4,11 @@ MVC
 
 .. automodule:: spectate.mvc.base
     :members:
+    :ignore-module-all:
 
 .. automodule:: spectate.mvc.models
     :members:
+    :ignore-module-all:
 
 .. automodule:: spectate.mvc.utils
     :members:

--- a/spectate/mvc/utils.py
+++ b/spectate/mvc/utils.py
@@ -11,39 +11,16 @@ class Sentinel:
         return self.__name
 
 
-class completemethod:
-
-    _class_method = None
-    _instance_method = None
-
-    def __init__(self, function):
-        self._class_method = function
-
-    def __call__(self, function):
-        self._instance_method = function
-        return self
-
-    def __set_name__(self, cls, name):
-        if self._class_method is None:
-            raise TypeError('No class method defined.')
-        elif self._instance_method is None:
-            raise TypeError('No instance method defined.')
-
-    def __get__(self, obj, cls):
-        if obj is None:
-            return types.MethodType(self._class_method, cls)
-        else:
-            return types.MethodType(self._instance_method, obj)
-
-
 def memory_safe_function(function):
     """Return a memory safe copy of a function.
 
     Through some clever tricks, all the defauts, and closure of this function
     are turned into proxy objects wherever possible. **Making a function memory
-    safe may require its parent scope to be modified** - if the function contains
+    safe requires its parent scope to be modified** - if the function contains
     a ``list``, ``dict``, or ``set`` in its closure or default arguments, all
     values contained in those data structures will be converted to proxy objects!
+    Thus the user must keep references to those objects alive outside those data
+    structures.
 
     Parameters
     ----------

--- a/tests/test_mvc.py
+++ b/tests/test_mvc.py
@@ -1,11 +1,76 @@
 import sys
-from pytest import importorskip
+from pytest import importorskip, fixture, raises
 
 # skips for python 3.6 or less
 mvc = importorskip('spectate.mvc')
+from spectate.spectate import MethodSpectator
 
 
-def test_mvc_custom_model():
+def model_events(mtype, *args, **kwargs):
+    events = []
+    model = mtype(*args, **kwargs)
+
+    @mvc.view(model)
+    def cache(e):
+        events.append(e)
+
+    return model, events
+
+
+class TestControl:
+
+    def test_control_is_only_for_model(self):
+        """Controls must be defined on a Model"""
+        with raises(RuntimeError):
+            class X:
+                _control = mvc.Control()
+
+    def test_control_decoration(self):
+
+        calls = []
+
+        class X(mvc.Model):
+
+            def method(self):
+                pass
+
+            control = mvc.Control('method')
+
+            @control.before
+            def control(self, call, notify):
+                calls.append('before')
+
+            @control.after
+            def control(self, call, notify):
+                calls.append('after')
+
+        assert isinstance(X.method, MethodSpectator)
+
+        X().method()
+        assert calls == ['before', 'after']
+
+
+    def test_control_string_reference(self):
+
+        calls = []
+
+        class X(mvc.Model):
+
+            def method(self): pass
+
+            control = mvc.Control('method').before('before').after('after')
+
+            def before(self, call, notify):
+                calls.append('before')
+
+            def after(self, answer, notify):
+                calls.append('after')
+
+        X().method()
+        assert calls == ['before', 'after']
+
+
+class TestView:
 
     class Counter(mvc.Model):
 
@@ -19,7 +84,9 @@ def test_mvc_custom_model():
             self.x -= amount
 
         # define a beforeback for increment and decrement
-        @mvc.control.before('increment', 'decrement')
+        _control_change = mvc.Control('increment', 'decrement')
+
+        @_control_change.before
         def _control_change(self, call, notify):
             return self.x
 
@@ -29,27 +96,55 @@ def test_mvc_custom_model():
             # Send an "event" dictionary to the Counter's views.
             notify(old=answer.before, new=self.x)
 
-    counter = Counter()
-    events = []
+    def test_custom(self):
+        counter, events = model_events(self.Counter)
 
-    @mvc.view(counter)
-    def printer(e):
-        events.append(e)
+        counter.increment(1)
+        counter.decrement(2)
+        counter.increment(3)
+        counter.decrement(4)
 
-    counter.increment(1)
-    counter.decrement(2)
-    counter.increment(3)
-    counter.decrement(4)
+        assert events == [
+            {'old': 0, 'new': 1},
+            {'old': 1, 'new': -1},
+            {'old': -1, 'new': 2},
+            {'old': 2, 'new': -2},
+        ]
 
-    assert events == [
-        {'old': 0, 'new': 1},
-        {'old': 1, 'new': -1},
-        {'old': -1, 'new': 2},
-        {'old': 2, 'new': -2},
-    ]
+    def test_hold(self):
+        counter, events = model_events(self.Counter)
+
+        with mvc.hold(counter) as cache:
+            counter.increment(1)
+            assert cache == [
+                {'old': 0, 'new': 1},
+            ]
+
+            counter.increment(1)
+            assert cache == [
+                {'old': 0, 'new': 1},
+                {'old': 1, 'new': 2},
+            ]
+
+            # Pop off one of the events so
+            # it isn't sent to notifiers.
+            cache.pop()
+
+        assert events == [
+            {'old': 0, 'new': 1},
+        ]
+
+    def test_mute(self):
+        counter, events = model_events(self.Counter)
+
+        with mvc.mute(counter) as cache:
+            counter.increment(1)
+            counter.increment(1)
+
+        assert events == []
 
 
-def test_view_memory_safety():
+def test_memory_safety():
 
     l = mvc.List()
 

--- a/tests/test_spectate.py
+++ b/tests/test_spectate.py
@@ -256,6 +256,8 @@ def test_data_evolution():
     assert d4 == d0
     d5 = d4[{'a': None}]
     assert d5 == {}
+    d6 = d5[{'a': 1}, {'b': 2}]
+    assert d6 == {'a': 1, 'b': 2}
 
 def test_data_is_mapping():
     assert dict(Data(a=0, b=1)) == {'a': 0, 'b': 1}


### PR DESCRIPTION
The main user facing change has to do with how model controls are defined:

```python
from spectate import mvc


class Counter(mvc.Model):

    def __init__(self):
        self.x = 0

    def increment(self, amount):
        self.x += amount

    def decrement(self, amount):
        self.x -= amount

    # define a control for incrementing and decrementing
    _control_change = mvc.Control('increment', 'decrement')

    # register a beforeback to the control
    @_control_change.before
    def _control_change(self, call, notify):
        return self.x

    # register an afterback to the control
    @_control_change.after
    def _control_change(self, answer, notify):
        # Send an "event" dictionary to the Counter's views.
        notify(old=answer.before, new=self.x)
```

The docs and tests have been updated to reflect this.