### PR TITLE
Fix Inspect Warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sphinx_materialdesign_theme
 
 pytest
 pytest-cov
+funcsigs

--- a/spectate/_version.py
+++ b/spectate/_version.py
@@ -1,2 +1,2 @@
-info = (0, 2, 1,)
+info = (0, 2, 2,)
 __version__ = '.'.join(map(str, info))

--- a/tests/test_spectate.py
+++ b/tests/test_spectate.py
@@ -102,12 +102,13 @@ def test_method_spectator():
     assert wl == [1, 2]
 
 
-def test_method_spectator_argspec():
+def test_method_spectator_signature():
     WatchableThing = expose_as("WatchableThing", Thing, 'func')
     thing, sectator = watched(WatchableThing)
     assert MethodSpectator._compile_count == 2
-    assert (inspect.getargspec(Thing().func) ==
-        inspect.getargspec(thing.func))
+    assert (
+        inspect.signature(Thing().func) == inspect.signature(thing.func)
+    )
 
 
 def check_answer(checklist, inst, name, a, b, c=None, d=None, *e, **f):

--- a/tests/test_spectate.py
+++ b/tests/test_spectate.py
@@ -7,6 +7,11 @@ from spectate.spectate import (
     MethodSpectator, Spectator, Data,
 )
 
+try:
+    from inspect import signature
+except ImportError:
+    from funcsigs import signature
+
 
 def test_watchable():
     assert watchable(Watchable)
@@ -107,7 +112,7 @@ def test_method_spectator_signature():
     thing, sectator = watched(WatchableThing)
     assert MethodSpectator._compile_count == 2
     assert (
-        inspect.signature(Thing().func) == inspect.signature(thing.func)
+        signature(Thing().func) == signature(thing.func)
     )
 
 


### PR DESCRIPTION
Argspec is deprecated. Use `inspect.signature` or `funcsigs.signature` instead.