### PR TITLE
Auto-View Inner Models

### DIFF
--- a/docs/source/usage/create-models.rst
+++ b/docs/source/usage/create-models.rst
@@ -83,10 +83,10 @@ receive when they are called.
         def decrement(self, amount):
             self.value -= amount
 
-        _control_change = (
-            mvc.Control('increment', 'decrement')
-            .before("_before_change")
-            .after("_after_change")
+        _control_change = mvc.Control(
+            ["increment", "decrement"],
+            before="_before_change",
+            after="_after_change",
         )
 
         def _before_change(self, call, notify):
@@ -155,10 +155,10 @@ between the state before and the state after a change takes place:
         def decrement(self, amount):
             self.value -= amount
 
-        _control_change = (
-            mvc.Control('increment', 'decrement')
-            .before("_before_change")
-            .after("_after_change")
+        _control_change = mvc.Control(
+            ["increment", "decrement"],
+            before="_before_change",
+            after="_after_change",
         )
 
         def _before_change(self, call, notify):

--- a/examples/advanced.py
+++ b/examples/advanced.py
@@ -2,7 +2,7 @@ from spectate import expose, watch
 
 
 @expose("__setattr__", "__delattr__")
-class Data(object):
+class Immutable(object):
     def __init__(self):
         self._callbacks = []
         spectator = watch(self)
@@ -27,7 +27,7 @@ class Data(object):
         return function
 
 
-class User(Data):
+class User(Immutable):
     def __init__(self, name, description):
         super(User, self).__init__()
         self.name = name

--- a/spectate/core.py
+++ b/spectate/core.py
@@ -421,7 +421,7 @@ class Immutable(Mapping):
 
     def __setattr__(self, key, value):
         if key.startswith("_%s" % type(self).__name__):
-            super().__setattr__(key, value)
+            super(Immutable, self).__setattr__(key, value)
         else:
             raise TypeError("%r is immutable")
 

--- a/spectate/mvc/base.py
+++ b/spectate/mvc/base.py
@@ -120,8 +120,8 @@ def notifier(model):
     """
     events = []
 
-    def notify(**event):
-        events.append(Immutable(event))
+    def notify(*args, **kwargs):
+        events.append(Immutable(*args, **kwargs))
 
     yield notify
 

--- a/spectate/mvc/base.py
+++ b/spectate/mvc/base.py
@@ -1,6 +1,6 @@
 # See End Of File For Licensing
 from inspect import signature
-from functools import wraps, partial
+from functools import wraps
 from typing import Union, Callable, Optional
 from contextlib import contextmanager
 from weakref import WeakValueDictionary
@@ -148,8 +148,8 @@ class Control:
     Parameters:
         methods:
             The names of the methods on the model which this control will react to
-            When they are calthrough the Nodeled. This is either a comma seperated string,
-            or a list of strings.
+            When they are calthrough the Nodeled. This is either a comma seperated
+            string, or a list of strings.
         before:
             A control method that reacts before any of the given ``methods`` are
             called. If given as a callable, then that function will be used as the

--- a/spectate/mvc/events.py
+++ b/spectate/mvc/events.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from typing import Iterator, Callable, Optional
 
-from spectate import Data
+from spectate import Immutable
 
 from .base import Model
 
@@ -71,7 +71,7 @@ def hold(model: Model, reducer: Optional[Callable] = None) -> Iterator[list]:
         events = tuple(events)
 
         if reducer is not None:
-            events = tuple(map(Data, reducer(model, events)))
+            events = tuple(map(Immutable, reducer(model, events)))
 
         model._notify_model_views(events)
 

--- a/spectate/mvc/models.py
+++ b/spectate/mvc/models.py
@@ -16,50 +16,40 @@ Undefined = Sentinel("Undefined")
 class List(Model, list):
     """A :mod:`spectate.mvc` enabled ``list``."""
 
-    _control_setitem = (
-        Control("__setitem__")
-        .before("_control_before_setitem")
-        .after("_control_after_setitem")
+    _control_setitem = Control(
+        "__setitem__", before="_control_before_setitem", after="_control_after_setitem"
     )
 
-    _control_delitem = (
-        Control("__delitem__")
-        .before("_control_before_delitem")
-        .after("_control_after_delitem")
+    _control_delitem = Control(
+        "__delitem__", before="_control_before_delitem", after="_control_after_delitem"
     )
 
-    _control_insert = (
-        Control("insert")
-        .before("_control_before_insert")
-        .after("_control_after_insert")
+    _control_insert = Control(
+        "insert", before="_control_before_insert", after="_control_after_insert"
     )
 
-    _control_append = Control("append").after("_control_after_append")
+    _control_append = Control("append", after="_control_after_append")
 
-    _control_extend = (
-        Control("extend")
-        .before("_control_before_extend")
-        .after("_control_after_extend")
+    _control_extend = Control(
+        "extend", before="_control_before_extend", after="_control_after_extend"
     )
 
-    _control_pop = (
-        Control("pop").before("_control_before_pop").after("_control_after_delitem")
+    _control_pop = Control(
+        "pop", before="_control_before_pop", after="_control_after_delitem"
     )
 
-    _control_clear = (
-        Control("clear").before("_control_before_clear").after("_control_after_clear")
+    _control_clear = Control(
+        "clear", before="_control_before_clear", after="_control_after_clear"
     )
 
-    _control_remove = (
-        Control("remove")
-        .before("_control_before_remove")
-        .after("_control_after_delitem")
+    _control_remove = Control(
+        "remove", before="_control_before_remove", after="_control_after_delitem"
     )
 
-    _control_rearrangement = (
-        Control("sort", "reverse")
-        .before("_control_before_rearrangement")
-        .after("_control_after_rearrangement")
+    _control_rearrangement = Control(
+        ["sort", "reverse"],
+        before="_control_before_rearrangement",
+        after="_control_after_rearrangement",
     )
 
     def _control_before_setitem(self, call, notify):
@@ -143,26 +133,24 @@ class List(Model, list):
 class Dict(Model, dict):
     """A :mod:`spectate.mvc` enabled ``dict``."""
 
-    _control_setitem = (
-        Control("__setitem__", "setdefault")
-        .before("_control_before_setitem")
-        .after("_control_after_setitem")
+    _control_setitem = Control(
+        ["__setitem__", "setdefault"],
+        before="_control_before_setitem",
+        after="_control_after_setitem",
     )
 
-    _control_delitem = (
-        Control("__delitem__", "pop")
-        .before("_control_before_delitem")
-        .after("_control_after_delitem")
+    _control_delitem = Control(
+        ["__delitem__", "pop"],
+        before="_control_before_delitem",
+        after="_control_after_delitem",
     )
 
-    _control_update = (
-        Control("update")
-        .before("_control_before_update")
-        .after("_control_after_update")
+    _control_update = Control(
+        "update", before="_control_before_update", after="_control_after_update"
     )
 
-    _control_clear = (
-        Control("clear").before("_control_before_clear").after("_control_after_clear")
+    _control_clear = Control(
+        "clear", before="_control_before_clear", after="_control_after_clear"
     )
 
     def _control_before_setitem(self, call, notify):
@@ -217,8 +205,8 @@ class Dict(Model, dict):
 class Set(Model, set):
     """A :mod:`spectate.mvc` enabled ``set``."""
 
-    _control_update = (
-        Control(
+    _control_update = Control(
+        [
             "clear",
             "update",
             "difference_update",
@@ -228,9 +216,9 @@ class Set(Model, set):
             "remove",
             "symmetric_difference_update",
             "discard",
-        )
-        .before("_control_before_update")
-        .after("_control_after_update")
+        ],
+        before="_control_before_update",
+        after="_control_after_update",
     )
 
     def _control_before_update(self, call, notify):
@@ -246,10 +234,10 @@ class Set(Model, set):
 class Object(Model):
     """A :mod:`spectat.mvc` enabled ``object``."""
 
-    _control_attr_change = (
-        Control("__setattr__", "__delattr__")
-        .before("_control_before_attr_change")
-        .after("_control_after_attr_change")
+    _control_attr_change = Control(
+        ["__setattr__", "__delattr__"],
+        before="_control_before_attr_change",
+        after="_control_after_attr_change",
     )
 
     def __init__(self, *args, **kwargs):

--- a/spectate/mvc/models.py
+++ b/spectate/mvc/models.py
@@ -4,13 +4,23 @@ import inspect
 import itertools
 
 from .utils import Sentinel
-from .base import Structure, Control
+from .base import Model, Control
 
 
-__all__ = ["List", "Dict", "Set", "Object", "Undefined"]
+__all__ = ["Structure", "List", "Dict", "Set", "Object", "Undefined"]
 
 
 Undefined = Sentinel("Undefined")
+
+
+class Structure(Model):
+    def _notify_model_views(self, events):
+        for e in events:
+            if "new" in e and isinstance(e.new, Model):
+                self._attach_child_model(e.new)
+            if "old" in e and isinstance(e.old, Model):
+                self._remove_child_model(e.old)
+        super()._notify_model_views(events)
 
 
 class List(Structure, list):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,7 +11,7 @@ from spectate.core import (
     Watchable,
     MethodSpectator,
     Spectator,
-    Data,
+    Immutable,
 )
 
 try:
@@ -118,10 +118,10 @@ def test_method_spectator_signature():
 def check_answer(checklist, inst, name, a, b, c=None, d=None, *e, **f):
     args, kwargs = condense(a, b, c, d, *e, **f)
     checklist.append(
-        Data(
+        Immutable(
             name=name,
             value=(inst, a, b, c, d, e, f),
-            before=Data(name=name, args=args, kwargs=kwargs),
+            before=Immutable(name=name, args=args, kwargs=kwargs),
         )
     )
     getattr(inst, name)(a, b, c, d, *e, **f)
@@ -172,7 +172,7 @@ def test_callback_closure():
 
         def closure(value):
             callbacks_called[1] += 1
-            assert checklist[-1] == Data(name=call.name, value=value, before=call)
+            assert checklist[-1] == Immutable(name=call.name, value=value, before=call)
 
         return closure
 
@@ -227,7 +227,7 @@ if not sys.version_info < (3, 6):
 
 
 def test_data_is_immutable():
-    d = Data(a=0)
+    d = Immutable(a=0)
     with raises(TypeError):
         d["a"] = 1
     with raises(TypeError):
@@ -239,20 +239,17 @@ def test_data_is_immutable():
     assert d == {"a": 0}
 
 
-def test_data_evolution():
-    d0 = Data(a=0)
-    d1 = d0["b":1]
-    assert d1 == {"a": 0, "b": 1}
-    d2 = d1["b":2, "c":3]
-    assert d2 == {"a": 0, "b": 2, "c": 3}
-    d3 = d2[{"b": 3, "c": 4}]
-    assert d3 == {"a": 0, "b": 3, "c": 4}
-
-    d0 = Data()
-    d1 = d0[{"a": 1}, {"b": 2}]
-    assert d1 == {"a": 1, "b": 2}
+def test_can_add_immutables():
+    d0 = Immutable()
+    d1 = d0 + {"a": 1}
+    d2 = d1 + {"b": 2}
+    d3 = d2 + {"a": 10, "b": 20}
+    assert d1 == {"a": 1}
+    assert d2 == {"a": 1, "b": 2}
+    assert d3 == {"a": 10, "b": 20}
 
 
 def test_data_is_mapping():
-    assert dict(Data(a=0, b=1)) == {"a": 0, "b": 1}
-    assert dict(**Data(a=0, b=1)) == {"a": 0, "b": 1}
+    assert Immutable(a=0, b=1) == {"a": 0, "b": 1}
+    assert dict(Immutable(a=0, b=1)) == {"a": 0, "b": 1}
+    assert dict(**Immutable(a=0, b=1)) == {"a": 0, "b": 1}

--- a/tests/test_mvc/mock.py
+++ b/tests/test_mvc/mock.py
@@ -28,10 +28,10 @@ class Counter(mvc.Model):
     def decrement(self, amount):
         self.value -= amount
 
-    _control_change = (
-        mvc.Control("increment", "decrement")
-        .before("_control_before_change")
-        .after("_control_after_change")
+    _control_change = mvc.Control(
+        ["increment", "decrement"],
+        before="_control_before_change",
+        after="_control_after_change",
     )
 
     def _control_before_change(self, call, notify):

--- a/tests/test_mvc/test_base.py
+++ b/tests/test_mvc/test_base.py
@@ -112,9 +112,8 @@ def test_delete_controls_in_subclass():
     assert events == []
 
 
-def test_auto_capture_inner_models():
-    class Container(mvc.Model):
-
+def test_structure_events():
+    class Container(mvc.Structure):
         def __init__(self, name):
             self.name = name
             self.value = None
@@ -122,7 +121,9 @@ def test_auto_capture_inner_models():
         def set(self, value):
             self.value = value
 
-        _control_changes = mvc.Control("set", before="_before_change", after="_after_change")
+        _control_changes = mvc.Control(
+            "set", before="_before_change", after="_after_change"
+        )
 
         def _before_change(self, call, notify):
             return self.value
@@ -156,8 +157,8 @@ def test_auto_capture_inner_models():
     assert calls == [s0]
     calls.clear()
 
-    # these should not trigger events because they are no longer attached
-    # to the root container s0
+    # these should not trigger events because they are no longer
+    # attached to the root container s0
     s1.set(None)
     s2.set(None)
 

--- a/tests/test_mvc/test_base.py
+++ b/tests/test_mvc/test_base.py
@@ -11,26 +11,24 @@ def test_control_is_only_for_model():
     with raises(RuntimeError):
 
         class X:
-            _control = mvc.Control()
+            _control = mvc.Control("something")
 
 
-def test_control_decoration():
+def test_control_using_functions():
 
     calls = []
+
+    def _control_before(value, call, notify):
+        calls.append("before")
+
+    def _control_after(value, call, notify):
+        calls.append("after")
 
     class X(mvc.Model):
         def method(self):
             calls.append("during")
 
-        control = mvc.Control("method")
-
-        @control.before
-        def control(self, call, notify):
-            calls.append("before")
-
-        @control.after
-        def control(self, call, notify):
-            calls.append("after")
+        control = mvc.Control("method", before=_control_before, after=_control_after)
 
     assert isinstance(X.method, MethodSpectator)
 
@@ -38,7 +36,7 @@ def test_control_decoration():
     assert calls == ["before", "during", "after"]
 
 
-def test_control_string_reference():
+def test_control_using_string_reference():
 
     calls = []
 
@@ -46,7 +44,7 @@ def test_control_string_reference():
         def method(self):
             pass
 
-        control = mvc.Control("method").before("before").after("after")
+        control = mvc.Control("method", before="before", after="after")
 
         def before(self, call, notify):
             calls.append("before")
@@ -90,7 +88,7 @@ def test_override_control_methods_in_subclass():
 def test_add_new_control_in_subclass():
     class MyCounter(Counter):
 
-        _added_control = mvc.Control("increment").before("_added_before")
+        _added_control = mvc.Control("increment", before="_added_before")
 
         def _added_before(self, call, notify):
             notify(message="before")
@@ -112,3 +110,55 @@ def test_delete_controls_in_subclass():
     counter.increment(1)
 
     assert events == []
+
+
+def test_auto_capture_inner_models():
+    class Container(mvc.Model):
+
+        def __init__(self, name):
+            self.name = name
+            self.value = None
+
+        def set(self, value):
+            self.value = value
+
+        _control_changes = mvc.Control("set", before="_before_change", after="_after_change")
+
+        def _before_change(self, call, notify):
+            return self.value
+
+        def _after_change(self, answer, notify):
+            notify(old=answer.before, new=self.value)
+
+        def __repr__(self):
+            return "Container(%r)" % self.name
+
+    s0 = Container("s0")
+    s1 = Container("s1")
+    s2 = Container("s2")
+
+    calls = []
+
+    @mvc.view(s0)
+    def on_change(value, events):
+        calls.append(value)
+
+    s0.set(s1)
+    s1.set(s2)
+    s2.set(None)
+
+    assert calls == [s0, s1, s2]
+    calls.clear()
+
+    # remove children
+    s0.set(None)
+
+    assert calls == [s0]
+    calls.clear()
+
+    # these should not trigger events because they are no longer attached
+    # to the root container s0
+    s1.set(None)
+    s2.set(None)
+
+    assert not calls


### PR DESCRIPTION
cc: @martinRenou

# Summary

When viewing a model which is a container we should automatically view all of its child models. For example, given a list of lists we should be able to track changes to the outer list, and to those inside it:

```python
[
    [1, 2, 3],
    [4, 5, 6],
]
```

To do this we can view events produced by models and determine when a child model has been added. When we determine that a child model has been added, all view functions from the parent model should be added to its child models. Events which indicate that a child has been added or removed correspond to events which contain a `new` and/or `old` key whose value is `Model` instance. When we encounter a `new` Model we add the parent's view functions to it, and when we encounter an `old` Model we will remove the parent's view functions from it.

# Example

Given the following scenario:

```python
from spectate import mvc

d0 = mvc.Dict()

@mvc.view(d0)
def on_change(value, events):
    print("model: ", value)
    for e in events:
        print(e)

d1 = mvc.Dict()
d0["a"] = d1
d1["b"] = "data"
```

We should expect the printout to be:

```
model: {'a': {}}
event: {'key': 'a', 'old': Undefined, 'new': {}}
model: {'b': 'data'}
event: {'key': 'b', 'old': Undefined, 'new': 'data'}
```

Which would indicate that we are able to view events on `d1` after it has been added as a child of `d0`

# Note

We won't add information about the location of a given model within the overall structure because it is hard to know the best way to communicate it. One might initially imagine that you could add a `path` key to an event with a list of indexes to the model which produced the event. However this becomes difficult to generalize in cases where you have mixed types (e.g. a list of dicts of objects).

It isn't impossible to get this sort of information though if you're willing to make your own models. For example, if we wanted to implement a "viewable" binary tree it might look a little like this:

```python
from spectate import mvc

class Node(mvc.Model):
    
    def __init__(self, data, parent=None):
        if parent is not None:
            mvc.link(parent, self)
        self.parent = parent
        self.left = None
        self.right = None
        self.data = data

    def add(self, data):
        if data <= self.data:
            if self.left is None:
                self.left = Node(data, self)
                with mvc.notifier(self) as notify:
                    notify(left=self.left, path=self.path())
            else:
                self.left.add(data)
        else:
            if self.right is None:
                self.right = Node(data, self)
                with mvc.notifier(self) as notify:
                    notify(right=self.right, path=self.path())
            else:
                self.right.add(data)

    def path(self):
        n = self
        path = []
        while n is not None:
            path.insert(0, n)
            n = n.parent
        return path

    def __repr__(self):
        return f"Node({self.data})"
```

When we try out this `Node` class we end up with events the propagate to a parent view with a path:

```python
root = Node(0)

@mvc.view(root)
def printer(value, events):
    list(map(print, events))

root.add(1)
root.add(0)
root.add(5)
root.add(2)
root.add(4)
root.add(3)
```

STDOUT

```
{'right': Node(1), 'path': [Node(0)]}
{'left': Node(0), 'path': [Node(0)]}
{'right': Node(5), 'path': [Node(0), Node(1)]}
{'left': Node(2), 'path': [Node(0), Node(1), Node(5)]}
{'right': Node(4), 'path': [Node(0), Node(1), Node(5), Node(2)]}
{'left': Node(3), 'path': [Node(0), Node(1), Node(5), Node(2), Node(4)]}
```