### PR TITLE
actually exclude tests from sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ pkg_root = os.path.join(here, name)
 package = dict(
     name=name,
     license="MIT",
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=["tests*"]),
     python_requires=">=3.6",
     description="Track changes to mutable data types.",
     classifiers=["Intended Audience :: Developers"],


### PR DESCRIPTION
Hi, thanks for `spectate`, and congratulations on 1.0.0!

This PR tunes up the `find_packages` to actually exclude the `tests` package... yeah I don't understand it either, but the 1.0.0 sdist still has that top-level package in it. :shrug: 

Thanks again!